### PR TITLE
CRYPTO-9: Rename configuration name in Chimera to Apache name space

### DIFF
--- a/src/main/java/org/apache/commons/crypto/cipher/CipherFactory.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/CipherFactory.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * This is the factory class used for creating cipher class
  */
 public class CipherFactory {
-  
+
   /** LOG instance for {@CipherFactory} */
   public final static Logger LOG = LoggerFactory.getLogger(CipherFactory.class);
 
@@ -70,7 +70,7 @@ public class CipherFactory {
 
   /**
    * Gets a cipher for algorithm/mode/padding in config value
-   * chimera.crypto.cipher.transformation
+   * commons.crypto.cipher.transformation
    *
    * @return Cipher the cipher object Null value will be returned if no
    *         cipher classes with transformation configured.

--- a/src/main/java/org/apache/commons/crypto/conf/ConfigurationKeys.java
+++ b/src/main/java/org/apache/commons/crypto/conf/ConfigurationKeys.java
@@ -25,25 +25,19 @@ import org.apache.commons.crypto.cipher.JceCipher;
 public class ConfigurationKeys {
 
   /**
-   * The prefix named with project name.
+   * The prefix of crypto configuration.
    */
-  public static final String CHIMERA_PREFIX = "chimera.";
+  public static final String CONF_PREFIX = "commons.crypto.";
 
   /**
    * The filename of configuration file.
    */
-  public static final String CHIMERA_SYSTEM_PROPERTIES_FILE =
-      CHIMERA_PREFIX + "properties";
-
-  /**
-   * The prefix of crypto configuration.
-   */
-  public static final String CONF_PREFIX =
-      CHIMERA_PREFIX + "crypto.";
+  public static final String COMMONS_CRYPTO_SYSTEM_PROPERTIES_FILE =
+      CONF_PREFIX + "properties";
 
   /**
    * The configuration key of implementation class for crypto cipher.
-   * The values of CHIMERA_CRYPTO_CIPHER_CLASSES_KEY can be
+   * The values of COMMONS_CRYPTO_CIPHER_CLASSES_KEY can be
    * "org.apache.commons.crypto.cipher.JceCipher" and "org.apache.commons.crypto.cipher.OpensslCipher".
    * And it takes a common separated list.
    * The "org.apache.commons.crypto.cipher.JceCipher" use jce provider to
@@ -52,49 +46,49 @@ public class ConfigurationKeys {
    * Note that for each value,the first value which can be created without exception
    * will be used (priority by order).
     */
-  public static final String CHIMERA_CRYPTO_CIPHER_CLASSES_KEY =
+  public static final String COMMONS_CRYPTO_CIPHER_CLASSES_KEY =
       CONF_PREFIX + "cipher.classes";
 
   /**
    * The default value for crypto cipher.
    */
-  public static final String CHIMERA_CRYPTO_CIPHER_CLASSES_DEFAULT =
+  public static final String COMMONS_CRYPTO_CIPHER_CLASSES_DEFAULT =
       JceCipher.class.getName();
 
   /**
    * The configuration key of the provider class for JCE cipher.
    */
-  public static final String CHIMERA_CRYPTO_CIPHER_JCE_PROVIDER_KEY =
+  public static final String COMMONS_CRYPTO_CIPHER_JCE_PROVIDER_KEY =
       CONF_PREFIX + "cipher.jce.provider";
 
   // security random related configuration keys
   /**
    * The configuration key of the file path for secure random device.
    */
-  public static final String CHIMERA_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_KEY =
+  public static final String COMMONS_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_KEY =
       CONF_PREFIX + "secure.random.device.file.path";
 
   /**
    * The default value of the file path for secure random device.
    */
-  public static final String CHIMERA_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_DEFAULT =
+  public static final String COMMONS_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_DEFAULT =
       "/dev/urandom";
 
   /**
    * The configuration key of the algorithm of secure random.
    */
-  public static final String CHIMERA_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_KEY =
+  public static final String COMMONS_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_KEY =
       CONF_PREFIX + "secure.random.java.algorithm";
 
   /**
    * The default value of the algorithm of secure random.
    */
   public static final String
-      CHIMERA_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_DEFAULT = "SHA1PRNG";
+      COMMONS_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_DEFAULT = "SHA1PRNG";
 
   /**
    * The configuration key of the implementation class for secure random.
-   * The values of CHIMERA_CRYPTO_SECURE_RANDOM_CLASSES_KEY can be
+   * The values of COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY can be
    * "org.apache.commons.crypto.random.JavaSecureRandom" and "org.apache.commons.crypto.random.OpensslSecureRandom".
    * And it takes a common separated list.
    * The "org.apache.commons.crypto.random.JavaSecureRandom" use java to
@@ -103,37 +97,37 @@ public class ConfigurationKeys {
    * Note that for each value,the first value which can be created without exception
    * will be used (priority by order).
    */
-  public static final String CHIMERA_CRYPTO_SECURE_RANDOM_CLASSES_KEY =
+  public static final String COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY =
       CONF_PREFIX + "secure.random.classes";
 
   /**
    * The configuration key of the buffer size for stream.
    */
-  public static final String CHIMERA_CRYPTO_STREAM_BUFFER_SIZE_KEY =
+  public static final String COMMONS_CRYPTO_STREAM_BUFFER_SIZE_KEY =
       CONF_PREFIX + "stream.buffer.size";
 
   // stream related configuration keys
   /**
    * The default value of the buffer size for stream.
    */
-  public static final int CHIMERA_CRYPTO_STREAM_BUFFER_SIZE_DEFAULT = 8192;
+  public static final int COMMONS_CRYPTO_STREAM_BUFFER_SIZE_DEFAULT = 8192;
 
   // native lib related configuration keys
   /**
    * The configuration key of the path for loading crypto library.
    */
-  public static final String CHIMERA_CRYPTO_LIB_PATH_KEY =
+  public static final String COMMONS_CRYPTO_LIB_PATH_KEY =
       CONF_PREFIX + "lib.path";
 
   /**
    * The configuration key of the file name for loading crypto library.
    */
-  public static final String CHIMERA_CRYPTO_LIB_NAME_KEY =
+  public static final String COMMONS_CRYPTO_LIB_NAME_KEY =
       CONF_PREFIX + "lib.name";
 
   /**
    * The configuration key of temp directory for extracting crypto library.
    */
-  public static final String CHIMERA_CRYPTO_LIB_TEMPDIR_KEY =
+  public static final String COMMONS_CRYPTO_LIB_TEMPDIR_KEY =
       CONF_PREFIX + "lib.tempdir";
 }

--- a/src/main/java/org/apache/commons/crypto/random/JavaSecureRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/JavaSecureRandom.java
@@ -43,8 +43,8 @@ public class JavaSecureRandom implements SecureRandom {
     try {
       instance = java.security.SecureRandom
           .getInstance(properties.getProperty(
-              ConfigurationKeys.CHIMERA_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_KEY,
-              ConfigurationKeys.CHIMERA_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_DEFAULT));
+              ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_KEY,
+              ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_DEFAULT));
     } catch (NoSuchAlgorithmException e) {
       LOG.error("Failed to create java secure random due to error: " + e);
     }

--- a/src/main/java/org/apache/commons/crypto/random/SecureRandomFactory.java
+++ b/src/main/java/org/apache/commons/crypto/random/SecureRandomFactory.java
@@ -26,7 +26,7 @@ import org.apache.commons.crypto.utils.Utils;
 import org.apache.commons.crypto.utils.ReflectionUtils;
 
 import static org.apache.commons.crypto.conf.ConfigurationKeys
-    .CHIMERA_CRYPTO_SECURE_RANDOM_CLASSES_KEY;
+    .COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY;
 
 /**
  * This is the factory class used for {@link SecureRandom}.
@@ -44,10 +44,10 @@ public class SecureRandomFactory {
    */
   public static SecureRandom getSecureRandom(Properties props) {
     String secureRandomClasses = props.getProperty(
-        CHIMERA_CRYPTO_SECURE_RANDOM_CLASSES_KEY);
+        COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY);
     if (secureRandomClasses == null) {
       secureRandomClasses = System.getProperty(
-          CHIMERA_CRYPTO_SECURE_RANDOM_CLASSES_KEY);
+          COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY);
     }
 
     SecureRandom random = null;

--- a/src/main/java/org/apache/commons/crypto/utils/Utils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/Utils.java
@@ -30,17 +30,17 @@ import org.apache.commons.crypto.cipher.Cipher;
 import org.apache.commons.crypto.cipher.CipherFactory;
 import org.apache.commons.crypto.cipher.CipherTransformation;
 
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_CRYPTO_STREAM_BUFFER_SIZE_DEFAULT;
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_CRYPTO_STREAM_BUFFER_SIZE_KEY;
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_CRYPTO_CIPHER_CLASSES_DEFAULT;
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_CRYPTO_CIPHER_CLASSES_KEY;
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_CRYPTO_CIPHER_JCE_PROVIDER_KEY;
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_CRYPTO_LIB_NAME_KEY;
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_CRYPTO_LIB_PATH_KEY;
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_DEFAULT;
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_KEY;
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_SYSTEM_PROPERTIES_FILE;
-import static org.apache.commons.crypto.conf.ConfigurationKeys.CHIMERA_CRYPTO_LIB_TEMPDIR_KEY;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_STREAM_BUFFER_SIZE_DEFAULT;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_STREAM_BUFFER_SIZE_KEY;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_CIPHER_CLASSES_DEFAULT;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_CIPHER_CLASSES_KEY;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_CIPHER_JCE_PROVIDER_KEY;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_LIB_NAME_KEY;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_LIB_PATH_KEY;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_DEFAULT;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_KEY;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_SYSTEM_PROPERTIES_FILE;
+import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_LIB_TEMPDIR_KEY;
 
 /**
  * General utility methods.
@@ -57,17 +57,17 @@ public class Utils {
   private static final int AES_BLOCK_SIZE = AES_CTR_NOPADDING.getAlgorithmBlockSize();
 
   static {
-    loadChimeraSystemProperties();
+    loadCommonsCryptoSystemProperties();
   }
 
   /**
    * loads system properties when configuration file of the name
-   * {@link #CHIMERA_SYSTEM_PROPERTIES_FILE} is found.
+   * {@link #COMMONS_CRYPTO_SYSTEM_PROPERTIES_FILE} is found.
    */
-  private static void loadChimeraSystemProperties() {
+  private static void loadCommonsCryptoSystemProperties() {
     try {
       InputStream is = Thread.currentThread().getContextClassLoader()
-          .getResourceAsStream(CHIMERA_SYSTEM_PROPERTIES_FILE);
+          .getResourceAsStream(COMMONS_CRYPTO_SYSTEM_PROPERTIES_FILE);
 
       if (is == null)
         return; // no configuration file is found
@@ -79,7 +79,7 @@ public class Utils {
       Enumeration<?> names = props.propertyNames();
       while (names.hasMoreElements()) {
         String name = (String) names.nextElement();
-        if (name.startsWith("chimera.")) {
+        if (name.startsWith("commons.crypto.")) {
           if (System.getProperty(name) == null) {
             System.setProperty(name, props.getProperty(name));
           }
@@ -87,7 +87,7 @@ public class Utils {
       }
     } catch (Throwable ex) {
       System.err.println("Could not load '"
-          + CHIMERA_SYSTEM_PROPERTIES_FILE + "' from classpath: "
+          + COMMONS_CRYPTO_SYSTEM_PROPERTIES_FILE + "' from classpath: "
           + ex.toString());
     }
   }
@@ -114,13 +114,13 @@ public class Utils {
    * */
   public static int getBufferSize(Properties props) {
     String bufferSizeStr = props.getProperty(
-        CHIMERA_CRYPTO_STREAM_BUFFER_SIZE_KEY);
+        COMMONS_CRYPTO_STREAM_BUFFER_SIZE_KEY);
     if (bufferSizeStr == null || bufferSizeStr.isEmpty()) {
       bufferSizeStr = System
-        .getProperty(CHIMERA_CRYPTO_STREAM_BUFFER_SIZE_KEY);
+        .getProperty(COMMONS_CRYPTO_STREAM_BUFFER_SIZE_KEY);
     }
     if (bufferSizeStr == null || bufferSizeStr.isEmpty()) {
-      return CHIMERA_CRYPTO_STREAM_BUFFER_SIZE_DEFAULT;
+      return COMMONS_CRYPTO_STREAM_BUFFER_SIZE_DEFAULT;
     } else {
       return Integer.parseInt(bufferSizeStr);
     }
@@ -134,9 +134,9 @@ public class Utils {
    * @return the cipher class based on the props.
    */
   public static String getCipherClassString(Properties props) {
-    final String configName = CHIMERA_CRYPTO_CIPHER_CLASSES_KEY;
+    final String configName = COMMONS_CRYPTO_CIPHER_CLASSES_KEY;
     return props.getProperty(configName) != null ? props.getProperty(configName) : System
-        .getProperty(configName, CHIMERA_CRYPTO_CIPHER_CLASSES_DEFAULT);
+        .getProperty(configName, COMMONS_CRYPTO_CIPHER_CLASSES_DEFAULT);
   }
 
   /**
@@ -147,9 +147,9 @@ public class Utils {
    * @return the jce provider based on the props.
    */
   public static String getJCEProvider(Properties props) {
-    return props.getProperty(CHIMERA_CRYPTO_CIPHER_JCE_PROVIDER_KEY) != null ?
-        props.getProperty(CHIMERA_CRYPTO_CIPHER_JCE_PROVIDER_KEY) :
-        System.getProperty(CHIMERA_CRYPTO_CIPHER_JCE_PROVIDER_KEY);
+    return props.getProperty(COMMONS_CRYPTO_CIPHER_JCE_PROVIDER_KEY) != null ?
+        props.getProperty(COMMONS_CRYPTO_CIPHER_JCE_PROVIDER_KEY) :
+        System.getProperty(COMMONS_CRYPTO_CIPHER_JCE_PROVIDER_KEY);
   }
 
   /**
@@ -161,11 +161,11 @@ public class Utils {
    */
   public static String getRandomDevPath(Properties props) {
     String devPath = props.getProperty(
-        CHIMERA_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_KEY);
+        COMMONS_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_KEY);
     if (devPath == null) {
       devPath = System.getProperty(
-          CHIMERA_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_KEY,
-          CHIMERA_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_DEFAULT);
+          COMMONS_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_KEY,
+          COMMONS_CRYPTO_SECURE_RANDOM_DEVICE_FILE_PATH_DEFAULT);
     }
     return devPath;
   }
@@ -176,7 +176,7 @@ public class Utils {
    * @return the path of native library.
    */
   public static String getLibPath() {
-    return System.getProperty(CHIMERA_CRYPTO_LIB_PATH_KEY);
+    return System.getProperty(COMMONS_CRYPTO_LIB_PATH_KEY);
   }
 
   /**
@@ -185,7 +185,7 @@ public class Utils {
    * @return the file name of native library.
    */
   public static String getLibName() {
-    return System.getProperty(CHIMERA_CRYPTO_LIB_NAME_KEY);
+    return System.getProperty(COMMONS_CRYPTO_LIB_NAME_KEY);
   }
 
   /**
@@ -194,7 +194,7 @@ public class Utils {
    * @return the temp directory.
    */
   public static String getTmpDir() {
-    return System.getProperty(CHIMERA_CRYPTO_LIB_TEMPDIR_KEY,
+    return System.getProperty(COMMONS_CRYPTO_LIB_TEMPDIR_KEY,
         System.getProperty("java.io.tmpdir"));
   }
 

--- a/src/main/java/org/apache/commons/crypto/utils/Utils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/Utils.java
@@ -29,6 +29,7 @@ import java.util.Properties;
 import org.apache.commons.crypto.cipher.Cipher;
 import org.apache.commons.crypto.cipher.CipherFactory;
 import org.apache.commons.crypto.cipher.CipherTransformation;
+import org.apache.commons.crypto.conf.ConfigurationKeys;
 
 import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_STREAM_BUFFER_SIZE_DEFAULT;
 import static org.apache.commons.crypto.conf.ConfigurationKeys.COMMONS_CRYPTO_STREAM_BUFFER_SIZE_KEY;
@@ -57,14 +58,14 @@ public class Utils {
   private static final int AES_BLOCK_SIZE = AES_CTR_NOPADDING.getAlgorithmBlockSize();
 
   static {
-    loadCommonsCryptoSystemProperties();
+    loadSystemProperties();
   }
 
   /**
    * loads system properties when configuration file of the name
    * {@link #COMMONS_CRYPTO_SYSTEM_PROPERTIES_FILE} is found.
    */
-  private static void loadCommonsCryptoSystemProperties() {
+  private static void loadSystemProperties() {
     try {
       InputStream is = Thread.currentThread().getContextClassLoader()
           .getResourceAsStream(COMMONS_CRYPTO_SYSTEM_PROPERTIES_FILE);
@@ -79,7 +80,7 @@ public class Utils {
       Enumeration<?> names = props.propertyNames();
       while (names.hasMoreElements()) {
         String name = (String) names.nextElement();
-        if (name.startsWith("commons.crypto.")) {
+        if (name.startsWith(ConfigurationKeys.CONF_PREFIX)) {
           if (System.getProperty(name) == null) {
             System.setProperty(name, props.getProperty(name));
           }

--- a/src/test/java/org/apache/commons/crypto/cipher/AbstractCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/AbstractCipherTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractCipherTest {
     Utils.checkNotNull(cipherClass);
     Utils.checkNotNull(transformations);
     props = new Properties();
-    props.setProperty(ConfigurationKeys.CHIMERA_CRYPTO_CIPHER_CLASSES_KEY,
+    props.setProperty(ConfigurationKeys.COMMONS_CRYPTO_CIPHER_CLASSES_KEY,
         cipherClass);
   }
 
@@ -180,7 +180,7 @@ public abstract class AbstractCipherTest {
       int[] bufferLenList = new int[] {2 * 1024 - 128, 2 * 1024 - 125};
       for (int bufferLen : bufferLenList) {
         resetCipher(transformation, key, iv);
-        
+
         int offset = 0;
         // encrypt (update + doFinal) the data
         int cipherPos = 0;

--- a/src/test/java/org/apache/commons/crypto/random/TestJavaSecureRandom.java
+++ b/src/test/java/org/apache/commons/crypto/random/TestJavaSecureRandom.java
@@ -28,7 +28,7 @@ public class TestJavaSecureRandom extends AbstractRandomTest {
   @Override
   public SecureRandom getSecureRandom() throws IOException {
     Properties props = new Properties();
-    props.setProperty(ConfigurationKeys.CHIMERA_CRYPTO_SECURE_RANDOM_CLASSES_KEY,
+    props.setProperty(ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY,
         JavaSecureRandom.class.getName());
     SecureRandom random = SecureRandomFactory.getSecureRandom(props);
     if ( !(random instanceof JavaSecureRandom)) {

--- a/src/test/java/org/apache/commons/crypto/random/TestOpensslSecureRandom.java
+++ b/src/test/java/org/apache/commons/crypto/random/TestOpensslSecureRandom.java
@@ -28,7 +28,7 @@ public class TestOpensslSecureRandom extends AbstractRandomTest {
   @Override
   public SecureRandom getSecureRandom() throws IOException {
     Properties props = new Properties();
-    props.setProperty(ConfigurationKeys.CHIMERA_CRYPTO_SECURE_RANDOM_CLASSES_KEY,
+    props.setProperty(ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY,
         OpensslSecureRandom.class.getName());
     SecureRandom random = SecureRandomFactory.getSecureRandom(props);
     if ( !(random instanceof OpensslSecureRandom)) {


### PR DESCRIPTION
We need to rename configuration names under the Apache name space.