### PR TITLE
CRYPTO-26 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/apache/commons/crypto/cipher/CipherFactory.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/CipherFactory.java
@@ -35,6 +35,8 @@ public class CipherFactory {
   /** LOG instance for {@CipherFactory} */
   public final static Logger LOG = LoggerFactory.getLogger(CipherFactory.class);
 
+  private CipherFactory() {}
+
   /**
    * Gets a cipher instance for specified algorithm/mode/padding.
    *

--- a/src/main/java/org/apache/commons/crypto/cipher/OpensslNative.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpensslNative.java
@@ -25,6 +25,8 @@ import java.nio.ByteBuffer;
  */
 public class OpensslNative {
 
+  private OpensslNative() {}
+
   /**
    * Declares a native method to initialize JNI field and method IDs.
    */

--- a/src/main/java/org/apache/commons/crypto/conf/ConfigurationKeys.java
+++ b/src/main/java/org/apache/commons/crypto/conf/ConfigurationKeys.java
@@ -130,4 +130,6 @@ public class ConfigurationKeys {
    */
   public static final String COMMONS_CRYPTO_LIB_TEMPDIR_KEY =
       CONF_PREFIX + "lib.tempdir";
+
+  private ConfigurationKeys() {}
 }

--- a/src/main/java/org/apache/commons/crypto/random/OpensslSecureRandomNative.java
+++ b/src/main/java/org/apache/commons/crypto/random/OpensslSecureRandomNative.java
@@ -23,6 +23,9 @@ package org.apache.commons.crypto.random;
  * OpensslSecureRandomNative.h(genereted by javah).
  */
 public class OpensslSecureRandomNative {
+
+  private OpensslSecureRandomNative() {}
+
   /**
    * Declares a native method to initialize SR.
    */

--- a/src/main/java/org/apache/commons/crypto/random/SecureRandomFactory.java
+++ b/src/main/java/org/apache/commons/crypto/random/SecureRandomFactory.java
@@ -35,6 +35,8 @@ public class SecureRandomFactory {
   public final static Logger LOG = LoggerFactory
       .getLogger(SecureRandomFactory.class);
 
+  private SecureRandomFactory() {}
+
   /**
    * Gets a SecureRandom instance for specified props.
    *

--- a/src/main/java/org/apache/commons/crypto/utils/IOUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/IOUtils.java
@@ -28,6 +28,8 @@ import org.apache.commons.logging.Log;
  */
 public class IOUtils {
 
+  private IOUtils() {}
+
   /**
    * Does the readFully based on the Input read.
    *

--- a/src/main/java/org/apache/commons/crypto/utils/NativeCodeLoader.java
+++ b/src/main/java/org/apache/commons/crypto/utils/NativeCodeLoader.java
@@ -43,6 +43,8 @@ public class NativeCodeLoader {
 
   private static boolean nativeCodeLoaded = false;
 
+  private NativeCodeLoader() {}
+
   static {
     // Try to load native library and set fallback flag appropriately
     if(LOG.isDebugEnabled()) {

--- a/src/main/java/org/apache/commons/crypto/utils/OSInfo.java
+++ b/src/main/java/org/apache/commons/crypto/utils/OSInfo.java
@@ -51,6 +51,8 @@ public class OSInfo {
    * The constant string represents for PPC64 architecture, the value is:{@value #PPC64}.*/
   public static final String PPC64 = "ppc64";
 
+  private OSInfo() {}
+
   static {
     // x86 mappings
     archMapping.put(X86, X86);

--- a/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
@@ -47,6 +47,8 @@ public class ReflectionUtils {
   private static final Class<?> NEGATIVE_CACHE_SENTINEL =
     NegativeCacheSentinel.class;
 
+  private ReflectionUtils() {}
+
   /**
    * A unique class which is used as a sentinel value in the caching
    * for getClassByName. {@link Cipher#getClassByNameOrNull(String)}.

--- a/src/main/java/org/apache/commons/crypto/utils/Utils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/Utils.java
@@ -57,6 +57,8 @@ public class Utils {
    */
   private static final int AES_BLOCK_SIZE = AES_CTR_NOPADDING.getAlgorithmBlockSize();
 
+  private Utils() {}
+
   static {
     loadSystemProperties();
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CRYPTO-26 Utility classes should not have public constructors.