### PR TITLE
CRYPTO-13: The API differences between apache.commons.crypto and JCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ String input = "hello world!";
 byte[] decryptedData = new byte[1024];
 // Encrypt
 ByteArrayOutputStream os = new ByteArrayOutputStream();
-CipherOutputStream cos = new CipherOutputStream(os, cipher, bufferSize, key, iv);
+CipherOutputStream cos = new CipherOutputStream(os, cipher, bufferSize,
+                                                new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
 cos.write(input.getBytes("UTF-8"));
 cos.flush();
 cos.close();
 
 // Decrypt
-CipherInputStream cis = new CipherInputStream(new ByteArrayInputStream(os.toByteArray()), cipher, bufferSize, key, iv);
+CipherInputStream cis = new CipherInputStream(new ByteArrayInputStream(os.toByteArray()), cipher, bufferSize,
+                                              new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
 int decryptedLen = cis.read(decryptedData, 0, 1024);
 
 ```

--- a/src/main/java/org/apache/commons/crypto/cipher/Cipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/Cipher.java
@@ -21,6 +21,8 @@ import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.spec.AlgorithmParameterSpec;
 import java.util.Properties;
 
 import javax.crypto.BadPaddingException;
@@ -63,7 +65,7 @@ public interface Cipher extends Closeable {
    * 
    * @param mode {@link #ENCRYPT_MODE} or {@link #DECRYPT_MODE}
    * @param key crypto key for the cipher
-   * @param iv Initialization vector for the cipher
+   * @param params the algorithm parameters
    * @throws InvalidKeyException if the given key is inappropriate for
    * initializing this cipher, or its keysize exceeds the maximum allowable
    * keysize (as determined from the configured jurisdiction policy files).
@@ -74,7 +76,7 @@ public interface Cipher extends Closeable {
    * the legal limits (as determined from the configured jurisdiction
    * policy files).
    */
-  void init(int mode, byte[] key, byte[] iv)
+  void init(int mode, Key key, AlgorithmParameterSpec params)
       throws InvalidKeyException, InvalidAlgorithmParameterException;
 
   /**

--- a/src/main/java/org/apache/commons/crypto/cipher/JceCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/JceCipher.java
@@ -21,6 +21,8 @@ import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.spec.AlgorithmParameterSpec;
 import java.util.Properties;
 
 import javax.crypto.BadPaddingException;
@@ -84,7 +86,7 @@ public class JceCipher implements Cipher {
    * 
    * @param mode {@link #ENCRYPT_MODE} or {@link #DECRYPT_MODE}
    * @param key crypto key for the cipher
-   * @param iv Initialization vector for the cipher
+   * @param params the algorithm parameters
    * @throws InvalidAlgorithmParameterException if the given algorithm
    * parameters are inappropriate for this cipher, or this cipher requires
    * algorithm parameters and <code>params</code> is null, or the given
@@ -93,17 +95,16 @@ public class JceCipher implements Cipher {
    * policy files).
    */
   @Override
-  public void init(int mode, byte[] key, byte[] iv)
+  public void init(int mode, Key key, AlgorithmParameterSpec params)
       throws InvalidKeyException, InvalidAlgorithmParameterException {
     Utils.checkNotNull(key);
-    Utils.checkNotNull(iv);
+    Utils.checkNotNull(params);
 
     int cipherMode = javax.crypto.Cipher.DECRYPT_MODE;
     if (mode == ENCRYPT_MODE)
       cipherMode = javax.crypto.Cipher.ENCRYPT_MODE;
 
-    cipher.init(cipherMode, new SecretKeySpec(key, "AES"),
-        new IvParameterSpec(iv));
+    cipher.init(cipherMode, key, params);
   }
 
   /**

--- a/src/main/java/org/apache/commons/crypto/stream/PositionedCipherInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/PositionedCipherInputStream.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.ShortBufferException;
+import javax.crypto.spec.IvParameterSpec;
 
 import org.apache.commons.crypto.cipher.Cipher;
 import org.apache.commons.crypto.cipher.CipherFactory;
@@ -261,7 +262,7 @@ public class PositionedCipherInputStream extends CTRCipherInputStream {
     final long counter = getCounter(position);
     Utils.calculateIV(getInitIV(), counter, iv);
     try {
-      state.getCipher().init(Cipher.DECRYPT_MODE, getKey(), iv);
+      state.getCipher().init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(iv));
     } catch (InvalidKeyException e) {
       throw new IOException(e);
     } catch (InvalidAlgorithmParameterException e) {

--- a/src/test/java/org/apache/commons/crypto/cipher/AbstractCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/AbstractCipherTest.java
@@ -23,6 +23,8 @@ import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.Properties;
 import java.util.Random;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
 
 import org.apache.commons.crypto.conf.ConfigurationKeys;
@@ -100,13 +102,13 @@ public abstract class AbstractCipherTest {
     dec = getCipher(transformation);
 
     try {
-      enc.init(Cipher.ENCRYPT_MODE, key, iv);
+      enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     } catch (Exception e) {
       Assert.fail("AES failed initialisation - " + e.toString());
     }
 
     try {
-      dec.init(Cipher.DECRYPT_MODE, key, iv);
+      dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     } catch (Exception e) {
       Assert.fail("AES failed initialisation - " + e.toString());
     }
@@ -217,13 +219,13 @@ public abstract class AbstractCipherTest {
     dec = getCipher(transformation);
 
     try {
-      enc.init(Cipher.ENCRYPT_MODE, key, iv);
+      enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     } catch (Exception e) {
       Assert.fail("AES failed initialisation - " + e.toString());
     }
 
     try {
-      dec.init(Cipher.DECRYPT_MODE, key, iv);
+      dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     } catch (Exception e) {
       Assert.fail("AES failed initialisation - " + e.toString());
     }

--- a/src/test/java/org/apache/commons/crypto/stream/AbstractCipherStreamTest.java
+++ b/src/test/java/org/apache/commons/crypto/stream/AbstractCipherStreamTest.java
@@ -43,6 +43,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
 public abstract class AbstractCipherStreamTest {
   private static final Log LOG= LogFactory.getLog(AbstractCipherStreamTest.class);
 
@@ -248,7 +251,8 @@ public abstract class AbstractCipherStreamTest {
     }
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    OutputStream out = new CipherOutputStream(baos, cipher, defaultBufferSize, key, iv);
+    OutputStream out = new CipherOutputStream(baos, cipher, defaultBufferSize,
+            new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     out.write(data);
     out.flush();
     out.close();
@@ -262,9 +266,10 @@ public abstract class AbstractCipherStreamTest {
       IOException {
     if (withChannel) {
       return new CipherInputStream(Channels.newChannel(bais), cipher,
-          bufferSize, key, iv);
+          bufferSize, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     } else {
-      return new CipherInputStream(bais, cipher, bufferSize, key, iv);
+      return new CipherInputStream(bais, cipher, bufferSize,
+              new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     }
   }
 
@@ -275,9 +280,10 @@ public abstract class AbstractCipherStreamTest {
       IOException {
     if (withChannel) {
       return new CipherOutputStream(Channels.newChannel(baos), cipher,
-          bufferSize, key, iv);
+          bufferSize, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     } else {
-      return new CipherOutputStream(baos, cipher, bufferSize, key, iv);
+      return new CipherOutputStream(baos, cipher, bufferSize,
+              new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     }
   }
 

--- a/src/test/java/org/apache/commons/crypto/stream/PositionedCipherInputStreamTest.java
+++ b/src/test/java/org/apache/commons/crypto/stream/PositionedCipherInputStreamTest.java
@@ -28,6 +28,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -78,7 +80,8 @@ public class PositionedCipherInputStreamTest {
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     // encryption data
-    OutputStream out = new CipherOutputStream(baos, cipher, bufferSize, key, iv);
+    OutputStream out = new CipherOutputStream(baos, cipher, bufferSize,
+            new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     out.write(testData);
     out.flush();
     out.close();


### PR DESCRIPTION
use the java Key and ParameterSpec class to pass the parameters for Cipher, CryptoInputStream and CryptoOutputStream.
While for CTRCryptoInputStream and CTRCryptoOutputStream, as it is specific to CTR mode whose parameter is known. So keep as it is.