### PR TITLE
CRYPTO-30: Mutable fields should be private

### DIFF
--- a/src/main/java/org/apache/commons/crypto/stream/CTRCipherInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CTRCipherInputStream.java
@@ -54,7 +54,7 @@ public class CTRCipherInputStream extends CipherInputStream {
   /**
    * Underlying stream offset
    */
-  protected long streamOffset = 0;
+  long streamOffset = 0;
 
   /**
    * The initial IV.
@@ -343,7 +343,7 @@ public class CTRCipherInputStream extends CipherInputStream {
 
   /**
    * Seeks the stream to a specific position relative to start of the under layer stream.
-   * 
+   *
    * @param position the given position in the data.
    * @throws IOException if an I/O error occurs.
    */
@@ -372,6 +372,10 @@ public class CTRCipherInputStream extends CipherInputStream {
    */
   protected long getStreamOffset() {
     return streamOffset;
+  }
+
+  protected void setStreamOffset(long streamOffset) {
+    this.streamOffset = streamOffset;
   }
 
   /**
@@ -618,5 +622,4 @@ public class CTRCipherInputStream extends CipherInputStream {
       throw new IOException(e);
     }
   }
-
 }

--- a/src/main/java/org/apache/commons/crypto/stream/CTRCipherOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CTRCipherOutputStream.java
@@ -53,7 +53,7 @@ public class CTRCipherOutputStream extends CipherOutputStream {
   /**
    * Underlying stream offset.
    */
-  protected long streamOffset = 0;
+  long streamOffset = 0;
 
   /**
    * The initial IV.
@@ -363,5 +363,23 @@ public class CTRCipherOutputStream extends CipherOutputStream {
     } catch (IllegalBlockSizeException e) {
       throw new IOException(e);
     }
+  }
+
+  /**
+   * Get the underlying stream offset
+   *
+   * @return the underlying stream offset
+   */
+  protected long getStreamOffset() {
+    return streamOffset;
+  }
+
+  /**
+   * Set the underlying stream offset
+   *
+   * @param streamOffset the underlying stream offset
+   */
+  protected void setStreamOffset(long streamOffset) {
+    this.streamOffset = streamOffset;
   }
 }

--- a/src/main/java/org/apache/commons/crypto/stream/CipherInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CipherInputStream.java
@@ -50,25 +50,25 @@ public class CipherInputStream extends InputStream implements
   private final byte[] oneByteBuf = new byte[1];
 
   /**The Cipher instance.*/
-  protected final Cipher cipher;
+  final Cipher cipher;
 
   /**The buffer size.*/
-  protected final int bufferSize;
+  final int bufferSize;
 
   /**Crypto key for the cipher.*/
-  protected final Key key;
+  final Key key;
 
   /** the algorithm parameters */
-  protected final AlgorithmParameterSpec params;
+  final AlgorithmParameterSpec params;
 
   /** Flag to mark whether the input stream is closed.*/
-  protected boolean closed;
+  private boolean closed;
 
   /** Flag to mark whether do final of the cipher to end the decrypting stream.*/
-  protected boolean finalDone = false;
+  private boolean finalDone = false;
 
   /**The input data.*/
-  protected Input input;
+  Input input;
 
   /**
    * Input data buffer. The data starts at inBuffer.position() and ends at
@@ -96,8 +96,8 @@ public class CipherInputStream extends InputStream implements
   public CipherInputStream(CipherTransformation transformation,
                            Properties props, InputStream in, Key key, AlgorithmParameterSpec params)
       throws IOException {
-    this(in, Utils.getCipherInstance(transformation, props),
-        Utils.getBufferSize(props), key, params);
+    this(in, Utils.getCipherInstance(transformation, props), Utils.getBufferSize(props), key,
+      params);
   }
 
   /**
@@ -421,6 +421,24 @@ public class CipherInputStream extends InputStream implements
    */
   protected Cipher getCipher() {
     return cipher;
+  }
+
+  /**
+   * Gets the specification of cryptographic parameters.
+   *
+   * @return the params.
+   */
+  protected AlgorithmParameterSpec getParams() {
+    return params;
+  }
+
+  /**
+   * Gets the input.
+   *
+   * @return the input.
+   */
+  protected Input getInput() {
+    return input;
   }
 
   /**

--- a/src/main/java/org/apache/commons/crypto/stream/CipherOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CipherOutputStream.java
@@ -52,34 +52,34 @@ public class CipherOutputStream extends OutputStream implements
   private final byte[] oneByteBuf = new byte[1];
 
   /** The output.*/
-  protected Output output;
+  Output output;
 
   /**the Cipher instance*/
-  protected final Cipher cipher;
+  final Cipher cipher;
 
   /**The buffer size.*/
-  protected final int bufferSize;
+  final int bufferSize;
 
   /**Crypto key for the cipher.*/
-  protected final Key key;
+  final Key key;
 
   /** the algorithm parameters */
-  protected final AlgorithmParameterSpec params;
+  final AlgorithmParameterSpec params;
 
   /** Flag to mark whether the output stream is closed.*/
-  protected boolean closed;
+  private boolean closed;
 
   /**
    * Input data buffer. The data starts at inBuffer.position() and ends at
    * inBuffer.limit().
    */
-  protected ByteBuffer inBuffer;
+  ByteBuffer inBuffer;
 
   /**
    * Encrypted data buffer. The data starts at outBuffer.position() and ends at
    * outBuffer.limit().
    */
-  protected ByteBuffer outBuffer;
+  ByteBuffer outBuffer;
 
   /**
    * Constructs a {@link org.apache.commons.crypto.stream.CipherOutputStream}.
@@ -92,11 +92,14 @@ public class CipherOutputStream extends OutputStream implements
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherOutputStream(CipherTransformation transformation,
-                            Properties props, OutputStream out, Key key, AlgorithmParameterSpec params)
-      throws IOException {
-    this(out, Utils.getCipherInstance(transformation, props),
-        Utils.getBufferSize(props), key, params);
+  public CipherOutputStream(
+    CipherTransformation transformation,
+    Properties props,
+    OutputStream out,
+    Key key,
+    AlgorithmParameterSpec params) throws IOException {
+    this(out, Utils.getCipherInstance(transformation, props), Utils.getBufferSize(props), key,
+      params);
   }
 
   /**
@@ -110,11 +113,14 @@ public class CipherOutputStream extends OutputStream implements
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherOutputStream(CipherTransformation transformation,
-                            Properties props, WritableByteChannel out, Key key, AlgorithmParameterSpec params)
-      throws IOException {
-    this(out, Utils.getCipherInstance(transformation, props),
-        Utils.getBufferSize(props), key, params);
+  public CipherOutputStream(
+    CipherTransformation transformation,
+    Properties props,
+    WritableByteChannel out,
+    Key key,
+    AlgorithmParameterSpec params) throws IOException {
+    this(out, Utils.getCipherInstance(transformation, props), Utils.getBufferSize(props), key,
+      params);
   }
 
   /**
@@ -392,5 +398,41 @@ public class CipherOutputStream extends OutputStream implements
   protected void freeBuffers() {
     Utils.freeDirectBuffer(inBuffer);
     Utils.freeDirectBuffer(outBuffer);
+  }
+
+  /**
+   * Gets the outBuffer.
+   *
+   * @return the outBuffer.
+   */
+  protected ByteBuffer getOutBuffer() {
+    return outBuffer;
+  }
+
+  /**
+   * Gets the internal Cipher.
+   *
+   * @return the cipher instance.
+   */
+  protected Cipher getCipher() {
+    return cipher;
+  }
+
+  /**
+   * Gets the buffer size.
+   *
+   * @return the buffer size.
+   */
+  protected int getBufferSize() {
+    return bufferSize;
+  }
+
+  /**
+   * Gets the inBuffer.
+   *
+   * @return the inBuffer.
+   */
+  protected ByteBuffer getInBuffer() {
+    return inBuffer;
   }
 }

--- a/src/main/java/org/apache/commons/crypto/stream/output/StreamOutput.java
+++ b/src/main/java/org/apache/commons/crypto/stream/output/StreamOutput.java
@@ -22,13 +22,13 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 /**
- * The StreamOutput class takes a <code>OutputStream</code> object and wraps it as 
+ * The StreamOutput class takes a <code>OutputStream</code> object and wraps it as
  * <code>Output</code> object acceptable by <code>CipherOutputStream</code> as the output target.
  */
 public class StreamOutput implements Output {
   private byte[] buf;
   private int bufferSize;
-  protected OutputStream out;
+  private OutputStream out;
 
   /**
    * Constructs a {@link org.apache.commons.crypto.stream.output.StreamOutput}.
@@ -55,7 +55,7 @@ public class StreamOutput implements Output {
   public int write(ByteBuffer src) throws IOException {
     final int len = src.remaining();
     final byte[] buf = getBuf();
-    
+
     int remaining = len;
     while(remaining > 0) {
       final int n = Math.min(remaining, bufferSize);
@@ -63,7 +63,7 @@ public class StreamOutput implements Output {
       out.write(buf, 0, n);
       remaining = src.remaining();
     }
-    
+
     return len;
   }
 
@@ -90,7 +90,7 @@ public class StreamOutput implements Output {
   public void close() throws IOException {
     out.close();
   }
-  
+
   private byte[] getBuf() {
     if (buf == null) {
       buf = new byte[bufferSize];
@@ -98,4 +98,7 @@ public class StreamOutput implements Output {
     return buf;
   }
 
+  protected OutputStream getOut() {
+    return out;
+  }
 }


### PR DESCRIPTION
Mutable fields should be private or possibly package-protected, never protected or public.