### PR TITLE
CRYPTO-36: Fix crypto web link

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -24,9 +24,9 @@
     </bannerRight>
     <body>
         <menu name="Documentation">
+            <item name="Overview"      href="/index.html"/>
             <item name="Download"
                    href="http://commons.apache.org/crypto/download_crypto.cgi"/>
-            <item name="Download" href="/download_crypto.html"/>
             <item name="Users guide"   href="/userguide.html"/>
             <item name="Javadoc trunk" href="/apidocs/index.html"/>            
         </menu>


### PR DESCRIPTION
Fixing: https://issues.apache.org/jira/browse/CRYPTO-36