### PR TITLE
CRYPTO-31: Make fields final wherever possible

### DIFF
--- a/src/main/java/org/apache/commons/crypto/random/JavaCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/JavaCryptoRandom.java
@@ -32,7 +32,7 @@ public class JavaCryptoRandom implements CryptoRandom {
   private static final Log LOG =
       LogFactory.getLog(JavaCryptoRandom.class.getName());
 
-  private java.security.SecureRandom instance;
+  private final java.security.SecureRandom instance;
 
   /**
    * Constructs a {@link org.apache.commons.crypto.random.JavaCryptoRandom}.
@@ -42,15 +42,9 @@ public class JavaCryptoRandom implements CryptoRandom {
    *         the specified algorithm.
    */
   public JavaCryptoRandom(Properties properties) throws NoSuchAlgorithmException {
-    try {
-      instance = java.security.SecureRandom
-          .getInstance(properties.getProperty(
-              ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_KEY,
-              ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_DEFAULT));
-    } catch (NoSuchAlgorithmException e) {
-      LOG.error("Failed to create java secure random due to error: " + e);
-      throw e;
-    }
+    instance = java.security.SecureRandom.getInstance(properties
+      .getProperty(ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_KEY,
+        ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_DEFAULT));
   }
 
   /**

--- a/src/main/java/org/apache/commons/crypto/random/OpensslCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/OpensslCryptoRandom.java
@@ -46,18 +46,21 @@ public class OpensslCryptoRandom extends Random implements CryptoRandom {
   private static final Log LOG =
       LogFactory.getLog(OpensslCryptoRandom.class.getName());
 
-  /** If native CryptoRandom unavailable, use java SecureRandom */
-  private JavaCryptoRandom fallback = null;
-  private static boolean nativeEnabled = false;
+  /** If native SecureRandom unavailable, use java SecureRandom */
+  private final JavaCryptoRandom fallback;
+  private static final boolean nativeEnabled;
+
   static {
+    boolean opensslLoaded = false;
     if (NativeCodeLoader.isNativeCodeLoaded()) {
       try {
         OpensslCryptoRandomNative.initSR();
-        nativeEnabled = true;
+        opensslLoaded = true;
       } catch (Throwable t) {
         LOG.error("Failed to load Openssl CryptoRandom", t);
       }
     }
+    nativeEnabled = opensslLoaded;
   }
 
   /**
@@ -79,6 +82,8 @@ public class OpensslCryptoRandom extends Random implements CryptoRandom {
   public OpensslCryptoRandom(Properties props) throws NoSuchAlgorithmException {
     if (!nativeEnabled) {
       fallback = new JavaCryptoRandom(props);
+    } else {
+      fallback = null;
     }
   }
 

--- a/src/main/java/org/apache/commons/crypto/stream/input/ChannelInput.java
+++ b/src/main/java/org/apache/commons/crypto/stream/input/ChannelInput.java
@@ -29,7 +29,7 @@ public class ChannelInput implements Input {
   private static final int SKIP_BUFFER_SIZE = 2048;
 
   private ByteBuffer buf;
-  private ReadableByteChannel channel;
+  private final ReadableByteChannel channel;
 
   /**
    * Constructs the {@link org.apache.commons.crypto.stream.input.ChannelInput}.

--- a/src/main/java/org/apache/commons/crypto/stream/input/StreamInput.java
+++ b/src/main/java/org/apache/commons/crypto/stream/input/StreamInput.java
@@ -26,9 +26,9 @@ import java.nio.ByteBuffer;
  * wraps it as <code>Input</code> object acceptable by <code>CryptoInputStream</code>.
  */
 public class StreamInput implements Input {
-  private byte[] buf;
-  private int bufferSize;
-  InputStream in;
+  private final byte[] buf;
+  private final int bufferSize;
+  final InputStream in;
 
   /**
    * Constructs a {@link org.apache.commons.crypto.stream.input.StreamInput}.
@@ -39,6 +39,7 @@ public class StreamInput implements Input {
   public StreamInput(InputStream inputStream, int bufferSize) {
     this.in = inputStream;
     this.bufferSize = bufferSize;
+    buf = new byte[bufferSize];
   }
 
   /**
@@ -56,17 +57,16 @@ public class StreamInput implements Input {
   @Override
   public int read(ByteBuffer dst) throws IOException {
     int remaining = dst.remaining();
-    final byte[] tmp = getBuf();
     int read = 0;
     while (remaining > 0) {
-      final int n = in.read(tmp, 0, Math.min(remaining, bufferSize));
+      final int n = in.read(buf, 0, Math.min(remaining, bufferSize));
       if (n == -1) {
         if (read == 0) {
           read = -1;
         }
         break;
       } else if (n > 0) {
-        dst.put(tmp, 0, n);
+        dst.put(buf, 0, n);
         read += n;
         remaining -= n;
       }
@@ -153,12 +153,5 @@ public class StreamInput implements Input {
   @Override
   public void close() throws IOException {
     in.close();
-  }
-
-  private byte[] getBuf() {
-    if (buf == null) {
-      buf = new byte[bufferSize];
-    }
-    return buf;
   }
 }

--- a/src/main/java/org/apache/commons/crypto/stream/output/StreamOutput.java
+++ b/src/main/java/org/apache/commons/crypto/stream/output/StreamOutput.java
@@ -26,9 +26,9 @@ import java.nio.ByteBuffer;
  * <code>Output</code> object acceptable by <code>CryptoOutputStream</code> as the output target.
  */
 public class StreamOutput implements Output {
-  private byte[] buf;
-  private int bufferSize;
-  private OutputStream out;
+  private final byte[] buf;
+  private final int bufferSize;
+  private final OutputStream out;
 
   /**
    * Constructs a {@link org.apache.commons.crypto.stream.output.StreamOutput}.
@@ -39,6 +39,7 @@ public class StreamOutput implements Output {
   public StreamOutput(OutputStream out, int bufferSize) {
     this.out = out;
     this.bufferSize = bufferSize;
+    buf = new byte[bufferSize];
   }
 
   /**
@@ -54,7 +55,6 @@ public class StreamOutput implements Output {
   @Override
   public int write(ByteBuffer src) throws IOException {
     final int len = src.remaining();
-    final byte[] buf = getBuf();
 
     int remaining = len;
     while(remaining > 0) {
@@ -89,13 +89,6 @@ public class StreamOutput implements Output {
   @Override
   public void close() throws IOException {
     out.close();
-  }
-
-  private byte[] getBuf() {
-    if (buf == null) {
-      buf = new byte[bufferSize];
-    }
-    return buf;
   }
 
   protected OutputStream getOut() {

--- a/src/main/java/org/apache/commons/crypto/utils/NativeCodeLoader.java
+++ b/src/main/java/org/apache/commons/crypto/utils/NativeCodeLoader.java
@@ -41,7 +41,7 @@ public class NativeCodeLoader {
   private static final Log LOG =
     LogFactory.getLog(NativeCodeLoader.class);
 
-  private static boolean nativeCodeLoaded = false;
+  private final static boolean nativeCodeLoaded;
 
   private NativeCodeLoader() {}
 
@@ -51,6 +51,7 @@ public class NativeCodeLoader {
       LOG.debug("Trying to load the custom-built native-commons-crypto library...");
     }
 
+    boolean nativeLoaded = false;
     try {
       File nativeLibFile = findNativeLibrary();
       if (nativeLibFile != null) {
@@ -61,19 +62,19 @@ public class NativeCodeLoader {
         System.loadLibrary("commons-crypto");
       }
       LOG.debug("Loaded the native library");
-      nativeCodeLoaded = true;
+      nativeLoaded = true;
     } catch (Throwable t) {
       // Ignore failure to load
-      if(LOG.isDebugEnabled()) {
+      if (LOG.isDebugEnabled()) {
         LOG.debug("Failed to load native library with error: " + t);
-        LOG.debug("java.library.path=" +
-            System.getProperty("java.library.path"));
+        LOG.debug("java.library.path=" + System.getProperty("java.library.path"));
       }
     }
 
+    nativeCodeLoaded = nativeLoaded;
     if (!nativeCodeLoaded) {
-      LOG.warn("Unable to load native library for the platform... " +
-               "using builtin-java classes where applicable");
+      LOG.warn("Unable to load native library for the platform... "
+        + "using builtin-java classes where applicable");
     }
   }
 

--- a/src/main/java/org/apache/commons/crypto/utils/OSInfo.java
+++ b/src/main/java/org/apache/commons/crypto/utils/OSInfo.java
@@ -25,7 +25,7 @@ import java.util.Locale;
  * Provides OS name and architecture name.
  */
 public class OSInfo {
-  private static HashMap<String, String> archMapping = new HashMap<String, String>();
+  private final static HashMap<String, String> archMapping = new HashMap<String, String>();
 
   /**
    * The constant string represents for X86 architecture, the value is: {@value #X86}.*/

--- a/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
@@ -33,12 +33,11 @@ public class ReflectionUtils {
   private static final Map<ClassLoader, Map<String, WeakReference<Class<?>>>>
     CACHE_CLASSES = new WeakHashMap<ClassLoader, Map<String, WeakReference<Class<?>>>>();
 
-  private static ClassLoader classLoader;
+  private final static ClassLoader classLoader;
+
   static {
-    classLoader = Thread.currentThread().getContextClassLoader();
-    if (classLoader == null) {
-      classLoader = CryptoCipher.class.getClassLoader();
-    }
+    ClassLoader threadClassLoader = Thread.currentThread().getContextClassLoader();
+    classLoader = (threadClassLoader != null) ? threadClassLoader : CryptoCipher.class.getClassLoader();
   }
 
   /**


### PR DESCRIPTION
Change the following fields as final:
```
JavaSecureRandom.instance
OpensslSecureRandom.fallback
OpensslSecureRandom.nativeEnabled
ChannelInput.channel
StreamInput.buf
StreamOutput.bufferSize
StreamOutput.buf
StreamOutput.out
static NativeCodeLoader.nativeCodeLoaded
static OSInfo.archMapping
static ReflectionUtils.classLoader
```