### PR TITLE
CRYPTO-33: avoid shadowing JVM class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include Makefile.common
 MVN:=mvn
 
 COMMONS_CRYPTO_OUT:=$(TARGET)/$(commons-crypto)-$(os_arch)
-COMMONS_CRYPTO_OBJ:=$(addprefix $(COMMONS_CRYPTO_OUT)/,OpensslSecureRandom.o OpensslNative.o)
+COMMONS_CRYPTO_OBJ:=$(addprefix $(COMMONS_CRYPTO_OUT)/,OpensslCryptoRandom.o OpensslNative.o)
 
 ifeq ($(OS_NAME),SunOS)
   TAR:= gtar
@@ -20,21 +20,21 @@ $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpensslNative.class : $(S
 	@mkdir -p $(TARGET)/jni-classes
 	$(JAVAC) -source 1.6 -target 1.6 -d $(TARGET)/jni-classes -sourcepath $(SRC) $<
 
-$(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslSecureRandomNative.class : $(SRC)/org/apache/commons/crypto/random/OpensslSecureRandomNative.java
+$(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslCryptoRandomNative.class : $(SRC)/org/apache/commons/crypto/random/OpensslCryptoRandomNative.java
 	@mkdir -p $(TARGET)/jni-classes
 	$(JAVAC) -source 1.6 -target 1.6 -d $(TARGET)/jni-classes -sourcepath $(SRC) $<
 
 $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpensslNative.h: $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpensslNative.class
 	$(JAVAH) -force -classpath $(TARGET)/jni-classes -o $@ org.apache.commons.crypto.cipher.OpensslNative
 
-$(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslSecureRandomNative.h: $(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslSecureRandomNative.class
-	$(JAVAH) -force -classpath $(TARGET)/jni-classes -o $@ org.apache.commons.crypto.random.OpensslSecureRandomNative
+$(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslCryptoRandomNative.h: $(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslCryptoRandomNative.class
+	$(JAVAH) -force -classpath $(TARGET)/jni-classes -o $@ org.apache.commons.crypto.random.OpensslCryptoRandomNative
 
 $(COMMONS_CRYPTO_OUT)/OpensslNative.o : $(SRC_NATIVE)/org/apache/commons/crypto/cipher/OpensslNative.c $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpensslNative.h
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-$(COMMONS_CRYPTO_OUT)/OpensslSecureRandom.o : $(SRC_NATIVE)/org/apache/commons/crypto/random/OpensslSecureRandomNative.c $(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslSecureRandomNative.h
+$(COMMONS_CRYPTO_OUT)/OpensslCryptoRandom.o : $(SRC_NATIVE)/org/apache/commons/crypto/random/OpensslCryptoRandomNative.c $(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslCryptoRandomNative.h
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/README.md
+++ b/README.md
@@ -1,87 +1,10 @@
-Chimera [![Build Status](https://travis-ci.org/intel-hadoop/chimera.svg?branch=master)](https://travis-ci.org/intel-hadoop/chimera) is a cryptographic library optimized with AES-NI (Advanced Encryption Standard New Instructions). It provides Java API for both cipher level and Java stream level. Developers can use it to implement high performance AES encryption/decryption with the minimum code and effort. Please note that Chimera doesn't implement the cryptographic algorithm such as AES directly. It wraps to Openssl or JCE which implement the algorithms.
+Apache Commons Crypto is a cryptographic library optimized with AES-NI (Advanced Encryption Standard New Instructions). It provides Java API for both cipher level and Java stream level. Developers can use it to implement high performance AES encryption/decryption with the minimum code and effort. Please note that Apache Commons Crypto doesn't implement the cryptographic algorithm such as AES directly. It wraps to Openssl or JCE which implement the algorithms.
 
 ## Features
   * Cipher API for low level cryptographic operations.
-  * Java stream API (CipherInputStream/CipherOutputStream) for high level stream encyrption/decryption.
+  * Java stream API (CryptoInputStream/CryptoOutputStream) for high level stream encyrption/decryption.
   * Both optimized with high performance AES encryption/decryption. (1400 MB/s - 1700 MB/s throughput in modern Xeon processors).
   * JNI-based implementation to achieve comparable performance to the native C++ version based on Openssl.
-  * Portable across various operating systems (currently only Linux); Chimera loads the library according to your machine environment (It looks system properties, `os.name` and `os.arch`). 
-  * Simple usage. Add the chimera-(version).jar file to your classpath.
+  * Portable across various operating systems (currently only Linux); Apache Commons Crypto loads the library according to your machine environment (It looks system properties, `os.name` and `os.arch`).
+  * Simple usage. Add the commons-crypto-(version).jar file to your classpath.
   * [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0). Free for both commercial and non-commercial use.
-
-## Download
-  * Release version: http://central.maven.org/maven2/org/apache/commons/crypto/chimera/
-  * Snapshot version (the latest beta version): https://oss.sonatype.org/content/repositories/snapshots/org/apache/commons/crypto/chimera/
-
-### Using with Maven
-  * Chimera is available from Maven's central repository:  <http://central.maven.org/maven2/org/apache/commons/crypto/chimera>
-
-Add the following dependency to your pom.xml:
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-crypto</artifactId>
-      <version>0.9.0</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
-
-### Using with sbt
-
-```
-libraryDependencies += "org.apache.commons" % "commons-crypto" % "0.9.0"
-```
-
-## Usage 
-
-```java
-
-Properties properties = new Properties();
-properties.setProperty("chimera.crypto.cipher.classes", "org.apache.commons.crypto.cipher.OpensslCipher");
-
-Cipher cipher = Utils.getCipherInstance(CipherTransformation.AES_CTR_NOPADDING, properties);
-byte[] key = new byte[16];
-byte[] iv = new byte[16];
-int bufferSize = 4096;
-String input = "hello world!";
-byte[] decryptedData = new byte[1024];
-// Encrypt
-ByteArrayOutputStream os = new ByteArrayOutputStream();
-CipherOutputStream cos = new CipherOutputStream(os, cipher, bufferSize,
-                                                new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
-cos.write(input.getBytes("UTF-8"));
-cos.flush();
-cos.close();
-
-// Decrypt
-CipherInputStream cis = new CipherInputStream(new ByteArrayInputStream(os.toByteArray()), cipher, bufferSize,
-                                              new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
-int decryptedLen = cis.read(decryptedData, 0, 1024);
-
-```
-
-### Configuration
-Currently, two ciphers are supported: JceCipher and OpensslCipher, you can configure which cipher to use as follows:
-
-    $ java -Dchimera.crypto.cipher.classes=org.apache.commons.crypto.cipher.OpensslCipher Sample
-    $ java -Dchimera.crypto.cipher.classes=org.apache.commons.crypto.cipher.JceCipher Sample
-
-More detailed information about the configurations are as follows.
-
-| Property Name | Default | Meaning         |
-| --------------|---------|-------------------------|
-| chimera.crypto.cipher.transformation | AES/CTR/NoPadding | The value is identical to the transformations described in the Cipher section of the Java Cryptography Architecture Standard Algorithm Name Documentation. Currently only "AES/CTR/NoPadding" algorithm is supported.|
-| chimera.crypto.cipher.classes | org.apache.commons.crypto.cipher.OpensslCipher, org.apache.commons.crypto.cipher.JceCipher | Comma-separated list of cipher classes which implement cipher algorithm of "AES/CTR/NoPadding". A cipher implementation encapsulates the encryption and decryption details. The first  available implementation appearing in this list will be used. |
-
-## Building from the source code
-Building from the source code is an option when your OS platform and CPU architecture is not supported. To build Chimera, you need JDK 1.7 or higher, OpenSSL 1.0.1c or higher, etc.
-
-    $ git clone https://github.com/intel-hadoop/chimera.git
-    $ cd chimera
-    $ mvn clean install
-
-A file `target/chimera-$(version).jar` is the product additionally containing the native library built for your platform.
-
-## Discussion
-For development related discussion, please go to [dev google group](https://groups.google.com/forum/#!forum/chimera-dev).
-For issues or bugs, please file tickets through [github](https://github.com/intel-hadoop/chimera/issues).

--- a/src/main/java/org/apache/commons/crypto/cipher/CryptoCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/CryptoCipher.java
@@ -32,17 +32,17 @@ import javax.crypto.ShortBufferException;
 /**
  * The interface of cryptographic cipher for encryption and decryption.
  */
-public interface Cipher extends Closeable {
+public interface CryptoCipher extends Closeable {
 
   /**
    * A constant representing encrypt mode.  The mode constant to be used
-   * when calling init method of the Cipher.
+   * when calling init method of the CryptoCipher.
    */
   int ENCRYPT_MODE = javax.crypto.Cipher.ENCRYPT_MODE;
 
   /**
    * A constant representing decrypt mode.  The mode constant to be used 
-   * when calling init method of the Cipher.
+   * when calling init method of the CryptoCipher.
    */
   int DECRYPT_MODE = javax.crypto.Cipher.DECRYPT_MODE;
 

--- a/src/main/java/org/apache/commons/crypto/cipher/CryptoCipherFactory.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/CryptoCipherFactory.java
@@ -30,12 +30,12 @@ import org.slf4j.LoggerFactory;
 /**
  * This is the factory class used for creating cipher class
  */
-public class CipherFactory {
+public class CryptoCipherFactory {
 
   /** LOG instance for {@CipherFactory} */
-  public final static Logger LOG = LoggerFactory.getLogger(CipherFactory.class);
+  public final static Logger LOG = LoggerFactory.getLogger(CryptoCipherFactory.class);
 
-  private CipherFactory() {}
+  private CryptoCipherFactory() {}
 
   /**
    * Gets a cipher instance for specified algorithm/mode/padding.
@@ -44,15 +44,15 @@ public class CipherFactory {
    *          the configuration properties
    * @param transformation
    *          algorithm/mode/padding
-   * @return Cipher the cipher. Null value will be returned if no
+   * @return CryptoCipher the cipher. Null value will be returned if no
    *         cipher classes with transformation configured.
    */
-  public static Cipher getInstance(CipherTransformation transformation,
-      Properties props) throws GeneralSecurityException {
-    List<Class<? extends Cipher>> klasses = getCipherClasses(props);
-    Cipher cipher = null;
+  public static CryptoCipher getInstance(CipherTransformation transformation,
+                                         Properties props) throws GeneralSecurityException {
+    List<Class<? extends CryptoCipher>> klasses = getCipherClasses(props);
+    CryptoCipher cipher = null;
     if (klasses != null) {
-      for (Class<? extends Cipher> klass : klasses) {
+      for (Class<? extends CryptoCipher> klass : klasses) {
         try {
           cipher = ReflectionUtils.newInstance(klass, props, transformation);
           if (cipher != null) {
@@ -61,7 +61,7 @@ public class CipherFactory {
             break;
           }
         } catch (Exception e) {
-          LOG.error("Cipher {} is not available or transformation {} is not " +
+          LOG.error("CryptoCipher {} is not available or transformation {} is not " +
             "supported.", klass.getName(), transformation.getName());
         }
       }
@@ -74,28 +74,28 @@ public class CipherFactory {
    * Gets a cipher for algorithm/mode/padding in config value
    * commons.crypto.cipher.transformation
    *
-   * @return Cipher the cipher object Null value will be returned if no
+   * @return CryptoCipher the cipher object Null value will be returned if no
    *         cipher classes with transformation configured.
    */
-  public static Cipher getInstance(CipherTransformation transformation)
+  public static CryptoCipher getInstance(CipherTransformation transformation)
       throws GeneralSecurityException {
     return getInstance(transformation, new Properties());
   }
 
   // Return OpenSSLCipher if Properties is null or empty by default
-  private static List<Class<? extends Cipher>> getCipherClasses(Properties props) {
-    List<Class<? extends Cipher>> result = new ArrayList<Class<? extends
-        Cipher>>();
+  private static List<Class<? extends CryptoCipher>> getCipherClasses(Properties props) {
+    List<Class<? extends CryptoCipher>> result = new ArrayList<Class<? extends
+            CryptoCipher>>();
     String cipherClassString = Utils.getCipherClassString(props);
 
     for (String c : Utils.splitClassNames(cipherClassString, ",")) {
       try {
         Class<?> cls = ReflectionUtils.getClassByName(c);
-        result.add(cls.asSubclass(Cipher.class));
+        result.add(cls.asSubclass(CryptoCipher.class));
       } catch (ClassCastException e) {
-        LOG.error("Class {} is not a Cipher.", c);
+        LOG.error("Class {} is not a CryptoCipher.", c);
       } catch (ClassNotFoundException e) {
-        LOG.error("Cipher {} not found.", c);
+        LOG.error("CryptoCipher {} not found.", c);
       }
     }
 

--- a/src/main/java/org/apache/commons/crypto/cipher/JceCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/JceCipher.java
@@ -32,15 +32,15 @@ import javax.crypto.ShortBufferException;
 import org.apache.commons.crypto.utils.Utils;
 
 /**
- * Implements the {@link org.apache.commons.crypto.cipher.Cipher} using JCE provider.
+ * Implements the {@link org.apache.commons.crypto.cipher.CryptoCipher} using JCE provider.
  */
-public class JceCipher implements Cipher {
+public class JceCipher implements CryptoCipher {
   private final Properties props;
   private final CipherTransformation transformation;
   private final javax.crypto.Cipher cipher;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.cipher.Cipher} based on JCE
+   * Constructs a {@link org.apache.commons.crypto.cipher.CryptoCipher} based on JCE
    * Cipher {@link javax.crypto.Cipher}.
    * @param props properties for JCE cipher
    * @param transformation transformation for JCE cipher

--- a/src/main/java/org/apache/commons/crypto/cipher/Openssl.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/Openssl.java
@@ -87,7 +87,7 @@ public final class Openssl {
       }
     } catch (Throwable t) {
       loadingFailure = t.getMessage();
-      LOG.debug("Failed to load OpenSSL Cipher.", t);
+      LOG.debug("Failed to load OpenSSL CryptoCipher.", t);
     } finally {
       loadingFailureReason = loadingFailure;
     }

--- a/src/main/java/org/apache/commons/crypto/cipher/OpensslCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpensslCipher.java
@@ -34,15 +34,15 @@ import javax.crypto.spec.IvParameterSpec;
 import org.apache.commons.crypto.utils.Utils;
 
 /**
- * Implements the Cipher using JNI into OpenSSL.
+ * Implements the CryptoCipher using JNI into OpenSSL.
  */
-public class OpensslCipher implements Cipher {
+public class OpensslCipher implements CryptoCipher {
   private final Properties props;
   private final CipherTransformation transformation;
   private final Openssl cipher;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.cipher.Cipher} using JNI into OpenSSL
+   * Constructs a {@link org.apache.commons.crypto.cipher.CryptoCipher} using JNI into OpenSSL
    * 
    * @param props properties for OpenSSL cipher
    * @param transformation transformation for OpenSSL cipher

--- a/src/main/java/org/apache/commons/crypto/cipher/package-info.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/package-info.java
@@ -17,6 +17,6 @@
  */
 
 /**
- * Cipher classes
+ * CryptoCipher classes
  */
 package org.apache.commons.crypto.cipher;

--- a/src/main/java/org/apache/commons/crypto/conf/ConfigurationKeys.java
+++ b/src/main/java/org/apache/commons/crypto/conf/ConfigurationKeys.java
@@ -17,7 +17,9 @@
  */
 package org.apache.commons.crypto.conf;
 
+import org.apache.commons.crypto.cipher.CryptoCipher;
 import org.apache.commons.crypto.cipher.OpensslCipher;
+import org.apache.commons.crypto.random.CryptoRandom;
 
 /**
  * The ConfigurationKeys contains Configuration keys and default values.
@@ -41,7 +43,7 @@ public class ConfigurationKeys {
    * "org.apache.commons.crypto.cipher.JceCipher" and "org.apache.commons.crypto.cipher.OpensslCipher".
    * And it takes a common separated list.
    * The "org.apache.commons.crypto.cipher.JceCipher" use jce provider to
-   * implement {@link org.apache.commons.crypto.cipher.Cipher} and
+   * implement {@link org.apache.commons.crypto.cipher.CryptoCipher} and
    * the "org.apache.commons.crypto.cipher.OpensslCipher" use jni into openssl to implement.
    * Note that for each value,the first value which can be created without exception
    * will be used (priority by order).
@@ -89,11 +91,11 @@ public class ConfigurationKeys {
   /**
    * The configuration key of the implementation class for secure random.
    * The values of COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY can be
-   * "org.apache.commons.crypto.random.JavaSecureRandom" and "org.apache.commons.crypto.random.OpensslSecureRandom".
+   * "org.apache.commons.crypto.random.JavaCryptoRandom" and "org.apache.commons.crypto.random.OpensslCryptoRandom".
    * And it takes a common separated list.
-   * The "org.apache.commons.crypto.random.JavaSecureRandom" use java to
-   * implement {@link org.apache.commons.crypto.random.SecureRandom} and
-   * the "org.apache.commons.crypto.random.OpensslSecureRandom" use jni into openssl to implement.
+   * The "org.apache.commons.crypto.random.JavaCryptoRandom" use java to
+   * implement {@link CryptoRandom} and
+   * the "org.apache.commons.crypto.random.OpensslCryptoRandom" use jni into openssl to implement.
    * Note that for each value,the first value which can be created without exception
    * will be used (priority by order).
    */

--- a/src/main/java/org/apache/commons/crypto/random/CryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/CryptoRandom.java
@@ -17,24 +17,20 @@
  */
 package org.apache.commons.crypto.random;
 
-import java.security.GeneralSecurityException;
-import java.util.Properties;
+import java.io.Closeable;
 
-import org.apache.commons.crypto.conf.ConfigurationKeys;
-import static junit.framework.Assert.fail;
+/**
+ * The interface for CryptoRandom.
+ */
+public interface CryptoRandom extends Closeable {
 
-public class TestOpensslSecureRandom extends AbstractRandomTest {
-
-  @Override
-  public SecureRandom getSecureRandom() throws GeneralSecurityException {
-    Properties props = new Properties();
-    props.setProperty(ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY,
-        OpensslSecureRandom.class.getName());
-    SecureRandom random = SecureRandomFactory.getSecureRandom(props);
-    if ( !(random instanceof OpensslSecureRandom)) {
-      fail("The SecureRandom should be: " + OpensslSecureRandom.class.getName());
-    }
-    return random;
-  }
+  /**
+   * Generates random bytes and places them into a user-supplied
+   * byte array.  The number of random bytes produced is equal to
+   * the length of the byte array.
+   *
+   * @param bytes the byte array to fill with random bytes
+   */
+  void nextBytes(byte[] bytes);
 
 }

--- a/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
+++ b/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
@@ -30,47 +30,47 @@ import static org.apache.commons.crypto.conf.ConfigurationKeys
     .COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY;
 
 /**
- * This is the factory class used for {@link SecureRandom}.
+ * This is the factory class used for {@link CryptoRandom}.
  */
-public class SecureRandomFactory {
+public class CryptoRandomFactory {
   public final static Logger LOG = LoggerFactory
-      .getLogger(SecureRandomFactory.class);
+      .getLogger(CryptoRandomFactory.class);
 
-  private SecureRandomFactory() {}
+  private CryptoRandomFactory() {}
 
   /**
-   * Gets a SecureRandom instance for specified props.
+   * Gets a CryptoRandom instance for specified props.
    *
    * @param props the configuration properties.
-   * @return SecureRandom the secureRandom object.Null value will be returned if no SecureRandom
+   * @return CryptoRandom the cryptoRandom object.Null value will be returned if no CryptoRandom
    *         classes with props.
-   * @throws GeneralSecurityException if fail to create the {@link SecureRandom}.
+   * @throws GeneralSecurityException if fail to create the {@link CryptoRandom}.
    */
-  public static SecureRandom getSecureRandom(Properties props) throws GeneralSecurityException {
-    String secureRandomClasses = props.getProperty(
+  public static CryptoRandom getCryptoRandom(Properties props) throws GeneralSecurityException {
+    String cryptoRandomClasses = props.getProperty(
         COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY);
-    if (secureRandomClasses == null) {
-      secureRandomClasses = System.getProperty(
+    if (cryptoRandomClasses == null) {
+      cryptoRandomClasses = System.getProperty(
           COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY);
     }
 
-    SecureRandom random = null;
-    if (secureRandomClasses != null) {
-      for (String klassName : Utils.splitClassNames(secureRandomClasses, ",")) {
+    CryptoRandom random = null;
+    if (cryptoRandomClasses != null) {
+      for (String klassName : Utils.splitClassNames(cryptoRandomClasses, ",")) {
         try {
           final Class<?> klass = ReflectionUtils.getClassByName(klassName);
-          random = (SecureRandom) ReflectionUtils.newInstance(klass, props);
+          random = (CryptoRandom) ReflectionUtils.newInstance(klass, props);
           if (random != null) {
             break;
           }
         } catch (ClassCastException e) {
-          LOG.error("Class {} is not a Cipher.", klassName);
+          LOG.error("Class {} is not a CryptoCipher.", klassName);
         } catch (ClassNotFoundException e) {
-          LOG.error("Cipher {} not found.", klassName);
+          LOG.error("CryptoCipher {} not found.", klassName);
         }
       }
     }
 
-    return (random == null) ? new JavaSecureRandom(props) : random;
+    return (random == null) ? new JavaCryptoRandom(props) : random;
   }
 }

--- a/src/main/java/org/apache/commons/crypto/random/JavaCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/JavaCryptoRandom.java
@@ -26,22 +26,22 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.commons.crypto.conf.ConfigurationKeys;
 
 /**
- * A SecureRandom of Java implementation.
+ * A CryptoRandom of Java implementation.
  */
-public class JavaSecureRandom implements SecureRandom {
+public class JavaCryptoRandom implements CryptoRandom {
   private static final Log LOG =
-      LogFactory.getLog(JavaSecureRandom.class.getName());
+      LogFactory.getLog(JavaCryptoRandom.class.getName());
 
   private java.security.SecureRandom instance;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.random.JavaSecureRandom}.
+   * Constructs a {@link org.apache.commons.crypto.random.JavaCryptoRandom}.
    *
    * @param properties the configuration properties.
    * @throws NoSuchAlgorithmException if no Provider supports a SecureRandomSpi implementation for
    *         the specified algorithm.
    */
-  public JavaSecureRandom(Properties properties) throws NoSuchAlgorithmException {
+  public JavaCryptoRandom(Properties properties) throws NoSuchAlgorithmException {
     try {
       instance = java.security.SecureRandom
           .getInstance(properties.getProperty(
@@ -55,7 +55,7 @@ public class JavaSecureRandom implements SecureRandom {
 
   /**
    * Overrides {@link java.lang.AutoCloseable#close()}.
-   * For{@link JavaSecureRandom}, we don't need to recycle resource.
+   * For{@link JavaCryptoRandom}, we don't need to recycle resource.
    */
   @Override
   public void close() {
@@ -63,7 +63,7 @@ public class JavaSecureRandom implements SecureRandom {
   }
 
   /**
-   * Overrides {@link org.apache.commons.crypto.random.SecureRandom#nextBytes(byte[])}.
+   * Overrides {@link org.apache.commons.crypto.random.CryptoRandom#nextBytes(byte[])}.
    * Generates random bytes and places them into a user-supplied byte array.
    * The number of random bytes produced is equal to the length of the byte array.
    *

--- a/src/main/java/org/apache/commons/crypto/random/OpensslCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/OpensslCryptoRandom.java
@@ -41,21 +41,21 @@ import org.apache.commons.crypto.utils.Utils;
  * @see https://wiki.openssl.org/index.php/Random_Numbers
  * @see http://en.wikipedia.org/wiki/RdRand
  */
-public class OpensslSecureRandom extends Random implements SecureRandom {
+public class OpensslCryptoRandom extends Random implements CryptoRandom {
   private static final long serialVersionUID = -7828193502768789584L;
   private static final Log LOG =
-      LogFactory.getLog(OpensslSecureRandom.class.getName());
+      LogFactory.getLog(OpensslCryptoRandom.class.getName());
 
-  /** If native SecureRandom unavailable, use java SecureRandom */
-  private JavaSecureRandom fallback = null;
+  /** If native CryptoRandom unavailable, use java SecureRandom */
+  private JavaCryptoRandom fallback = null;
   private static boolean nativeEnabled = false;
   static {
     if (NativeCodeLoader.isNativeCodeLoaded()) {
       try {
-        OpensslSecureRandomNative.initSR();
+        OpensslCryptoRandomNative.initSR();
         nativeEnabled = true;
       } catch (Throwable t) {
-        LOG.error("Failed to load Openssl SecureRandom", t);
+        LOG.error("Failed to load Openssl CryptoRandom", t);
       }
     }
   }
@@ -70,15 +70,15 @@ public class OpensslSecureRandom extends Random implements SecureRandom {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.random.OpensslSecureRandom}.
+   * Constructs a {@link org.apache.commons.crypto.random.OpensslCryptoRandom}.
    *
    * @param props the configuration properties.
    * @throws NoSuchAlgorithmException if no Provider supports a SecureRandomSpi implementation for
    *         the specified algorithm.
    */
-  public OpensslSecureRandom(Properties props) throws NoSuchAlgorithmException {
+  public OpensslCryptoRandom(Properties props) throws NoSuchAlgorithmException {
     if (!nativeEnabled) {
-      fallback = new JavaSecureRandom(props);
+      fallback = new JavaCryptoRandom(props);
     }
   }
 
@@ -90,14 +90,14 @@ public class OpensslSecureRandom extends Random implements SecureRandom {
    */
   @Override
   public void nextBytes(byte[] bytes) {
-    if (!nativeEnabled || !OpensslSecureRandomNative.nextRandBytes(bytes)) {
+    if (!nativeEnabled || !OpensslCryptoRandomNative.nextRandBytes(bytes)) {
       fallback.nextBytes(bytes);
     }
   }
 
   /**
-   * Overrides {@link OpensslSecureRandom}.
-   * For {@link OpensslSecureRandom}, we don't need to set seed.
+   * Overrides {@link OpensslCryptoRandom}.
+   * For {@link OpensslCryptoRandom}, we don't need to set seed.
    *
    * @param seed the initial seed.
    */

--- a/src/main/java/org/apache/commons/crypto/random/OpensslCryptoRandomNative.java
+++ b/src/main/java/org/apache/commons/crypto/random/OpensslCryptoRandomNative.java
@@ -18,13 +18,13 @@
 package org.apache.commons.crypto.random;
 
 /**
- * JNI interface of {@link SecureRandom} implementation.
+ * JNI interface of {@link CryptoRandom} implementation.
  * The native method in this class is defined in
- * OpensslSecureRandomNative.h(genereted by javah).
+ * OpensslCryptoRandomNative.h(genereted by javah).
  */
-public class OpensslSecureRandomNative {
+public class OpensslCryptoRandomNative {
 
-  private OpensslSecureRandomNative() {}
+  private OpensslCryptoRandomNative() {}
 
   /**
    * Declares a native method to initialize SR.
@@ -32,11 +32,11 @@ public class OpensslSecureRandomNative {
   public native static void initSR();
 
   /**
-   * Judges whether use {@link OpensslSecureRandomNative} to
+   * Judges whether use {@link OpensslCryptoRandomNative} to
    * generate the user-specified number of random bits.
    *
    * @param bytes the array to be filled in with random bytes.
-   * @return true if use {@link OpensslSecureRandomNative} to
+   * @return true if use {@link OpensslCryptoRandomNative} to
    * generate the user-specified number of random bits.
    */
   public native static boolean nextRandBytes(byte[] bytes); 

--- a/src/main/java/org/apache/commons/crypto/random/OsCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/OsCryptoRandom.java
@@ -32,8 +32,8 @@ import org.apache.commons.logging.LogFactory;
  * A Random implementation that uses random bytes sourced from the
  * operating system.
  */
-public class OsSecureRandom extends Random implements SecureRandom {
-  public static final Log LOG = LogFactory.getLog(OsSecureRandom.class);
+public class OsCryptoRandom extends Random implements CryptoRandom {
+  public static final Log LOG = LogFactory.getLog(OsCryptoRandom.class);
   
   private static final long serialVersionUID = 6391500337172057900L;
 
@@ -59,11 +59,11 @@ public class OsSecureRandom extends Random implements SecureRandom {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.random.OsSecureRandom}.
+   * Constructs a {@link org.apache.commons.crypto.random.OsCryptoRandom}.
    *
    * @param props the configuration properties.
    */
-  public OsSecureRandom(Properties props) {
+  public OsCryptoRandom(Properties props) {
     randomDevPath = Utils.getRandomDevPath(props);
     File randomDevFile = new File(randomDevPath);
 
@@ -83,7 +83,7 @@ public class OsSecureRandom extends Random implements SecureRandom {
   }
 
   /**
-   * Overrides {@link org.apache.commons.crypto.random.SecureRandom#nextBytes(byte[])}.
+   * Overrides {@link org.apache.commons.crypto.random.CryptoRandom#nextBytes(byte[])}.
    * Generates random bytes and places them into a user-supplied byte array.
    * The number of random bytes produced is equal to the length of the byte array.
    *

--- a/src/main/java/org/apache/commons/crypto/stream/CTRCryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CTRCryptoInputStream.java
@@ -30,7 +30,7 @@ import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.commons.crypto.cipher.Cipher;
+import org.apache.commons.crypto.cipher.CryptoCipher;
 import org.apache.commons.crypto.cipher.CipherTransformation;
 import org.apache.commons.crypto.stream.input.ChannelInput;
 import org.apache.commons.crypto.stream.input.Input;
@@ -38,7 +38,7 @@ import org.apache.commons.crypto.stream.input.StreamInput;
 import org.apache.commons.crypto.utils.Utils;
 
 /**
- * CTRCipherInputStream decrypts data. AES CTR mode is required in order to
+ * CTRCryptoInputStream decrypts data. AES CTR mode is required in order to
  * ensure that the plain text and cipher text have a 1:1 mapping. CTR crypto
  * stream has stream characteristic which is useful for implement features
  * like random seek. The decryption is buffer based. The key points of the
@@ -50,7 +50,7 @@ import org.apache.commons.crypto.utils.Utils;
  * <p/>
  * The underlying stream offset is maintained as state. It is not thread-safe.
  */
-public class CTRCipherInputStream extends CipherInputStream {
+public class CTRCryptoInputStream extends CryptoInputStream {
   /**
    * Underlying stream offset
    */
@@ -79,7 +79,7 @@ public class CTRCipherInputStream extends CipherInputStream {
   private boolean cipherReset = false;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherInputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -88,14 +88,14 @@ public class CTRCipherInputStream extends CipherInputStream {
    * @param iv Initialization vector for the cipher.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherInputStream(Properties props, InputStream in,
-      byte[] key, byte[] iv)
+  public CTRCryptoInputStream(Properties props, InputStream in,
+                              byte[] key, byte[] iv)
       throws IOException {
     this(props, in, key, iv, 0);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherInputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -104,29 +104,29 @@ public class CTRCipherInputStream extends CipherInputStream {
    * @param iv Initialization vector for the cipher.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherInputStream(Properties props, ReadableByteChannel in,
-      byte[] key, byte[] iv)
+  public CTRCryptoInputStream(Properties props, ReadableByteChannel in,
+                              byte[] key, byte[] iv)
       throws IOException {
     this(props, in, key, iv, 0);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherInputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
    *
    * @param in the input stream.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherInputStream(InputStream in, Cipher cipher, int bufferSize,
-      byte[] key, byte[] iv) throws IOException {
+  public CTRCryptoInputStream(InputStream in, CryptoCipher cipher, int bufferSize,
+                              byte[] key, byte[] iv) throws IOException {
     this(in, cipher, bufferSize, key, iv, 0);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherInputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
    *
    * @param in the ReadableByteChannel instance.
    * @param cipher the cipher instance.
@@ -135,24 +135,24 @@ public class CTRCipherInputStream extends CipherInputStream {
    * @param iv Initialization vector for the cipher.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherInputStream(ReadableByteChannel in, Cipher cipher,
-      int bufferSize, byte[] key, byte[] iv) throws IOException {
+  public CTRCryptoInputStream(ReadableByteChannel in, CryptoCipher cipher,
+                              int bufferSize, byte[] key, byte[] iv) throws IOException {
     this(in, cipher, bufferSize, key, iv, 0);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherInputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
    *
    * @param input the input data.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherInputStream(
+  public CTRCryptoInputStream(
       Input input,
-      Cipher cipher,
+      CryptoCipher cipher,
       int bufferSize,
       byte[] key,
       byte[] iv) throws IOException {
@@ -160,7 +160,7 @@ public class CTRCipherInputStream extends CipherInputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherInputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -170,15 +170,15 @@ public class CTRCipherInputStream extends CipherInputStream {
    * @param streamOffset the start offset in the stream.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherInputStream(Properties props, InputStream in,
-      byte[] key, byte[] iv, long streamOffset)
+  public CTRCryptoInputStream(Properties props, InputStream in,
+                              byte[] key, byte[] iv, long streamOffset)
       throws IOException {
     this(in, Utils.getCipherInstance(CipherTransformation.AES_CTR_NOPADDING, props),
         Utils.getBufferSize(props), key, iv, streamOffset);
   }
 
   /**
-   *Constructs a {@link org.apache.commons.crypto.stream.CTRCipherInputStream}.
+   *Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -188,59 +188,59 @@ public class CTRCipherInputStream extends CipherInputStream {
    * @param streamOffset the start offset in the stream.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherInputStream(Properties props, ReadableByteChannel in,
-      byte[] key, byte[] iv, long streamOffset)
+  public CTRCryptoInputStream(Properties props, ReadableByteChannel in,
+                              byte[] key, byte[] iv, long streamOffset)
       throws IOException {
     this(in, Utils.getCipherInstance(CipherTransformation.AES_CTR_NOPADDING, props),
         Utils.getBufferSize(props), key, iv, streamOffset);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherInputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
    *
    * @param in the InputStream instance.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @param streamOffset the start offset in the stream.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherInputStream(InputStream in, Cipher cipher, int bufferSize,
-      byte[] key, byte[] iv, long streamOffset) throws IOException {
+  public CTRCryptoInputStream(InputStream in, CryptoCipher cipher, int bufferSize,
+                              byte[] key, byte[] iv, long streamOffset) throws IOException {
     this(new StreamInput(in, bufferSize), cipher, bufferSize, key, iv, streamOffset);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherInputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
    *
    * @param in the ReadableByteChannel instance.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @param streamOffset the start offset in the stream.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherInputStream(ReadableByteChannel in, Cipher cipher,
-      int bufferSize, byte[] key, byte[] iv, long streamOffset) throws IOException {
+  public CTRCryptoInputStream(ReadableByteChannel in, CryptoCipher cipher,
+                              int bufferSize, byte[] key, byte[] iv, long streamOffset) throws IOException {
     this(new ChannelInput(in), cipher, bufferSize, key, iv, streamOffset);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherInputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
    *
    * @param input the input data.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @param streamOffset the start offset in the stream.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherInputStream(
+  public CTRCryptoInputStream(
       Input input,
-      Cipher cipher,
+      CryptoCipher cipher,
       int bufferSize,
       byte[] key,
       byte[] iv,
@@ -256,7 +256,7 @@ public class CTRCipherInputStream extends CipherInputStream {
   }
 
   /**
-   * Overrides the {@link org.apache.commons.crypto.stream.CipherInputStream#skip(long)}.
+   * Overrides the {@link org.apache.commons.crypto.stream.CryptoInputStream#skip(long)}.
    * Skips over and discards <code>n</code> bytes of data from this input
    * stream.
    *
@@ -295,7 +295,7 @@ public class CTRCipherInputStream extends CipherInputStream {
   }
 
   /**
-   * Overrides the {@link org.apache.commons.crypto.stream.CTRCipherInputStream#read(ByteBuffer)}.
+   * Overrides the {@link org.apache.commons.crypto.stream.CTRCryptoInputStream#read(ByteBuffer)}.
    * Reads a sequence of bytes from this channel into the given buffer.
    *
    * @param buf The buffer into which bytes are to be transferred.
@@ -548,7 +548,7 @@ public class CTRCipherInputStream extends CipherInputStream {
   }
 
   /**
-   * Overrides the {@link CTRCipherInputStream#initCipher()}.
+   * Overrides the {@link CTRCryptoInputStream#initCipher()}.
    * Initializes the cipher.
    */
   @Override
@@ -568,7 +568,7 @@ public class CTRCipherInputStream extends CipherInputStream {
     final long counter = getCounter(position);
     Utils.calculateIV(initIV, counter, iv);
     try {
-      cipher.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(iv));
+      cipher.init(CryptoCipher.DECRYPT_MODE, key, new IvParameterSpec(iv));
     } catch (InvalidKeyException e) {
       throw new IOException(e);
     } catch (InvalidAlgorithmParameterException e) {
@@ -607,9 +607,9 @@ public class CTRCipherInputStream extends CipherInputStream {
       int n = cipher.update(inBuffer, out);
       if (n < inputSize) {
         /**
-         * Typically code will not get here. Cipher#update will consume all
+         * Typically code will not get here. CryptoCipher#update will consume all
          * input data and put result in outBuffer.
-         * Cipher#doFinal will reset the cipher context.
+         * CryptoCipher#doFinal will reset the cipher context.
          */
         cipher.doFinal(inBuffer, out);
         cipherReset = true;

--- a/src/main/java/org/apache/commons/crypto/stream/CTRCryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CTRCryptoOutputStream.java
@@ -31,7 +31,7 @@ import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.commons.crypto.cipher.Cipher;
+import org.apache.commons.crypto.cipher.CryptoCipher;
 import org.apache.commons.crypto.cipher.CipherTransformation;
 import org.apache.commons.crypto.stream.output.ChannelOutput;
 import org.apache.commons.crypto.stream.output.Output;
@@ -39,7 +39,7 @@ import org.apache.commons.crypto.stream.output.StreamOutput;
 import org.apache.commons.crypto.utils.Utils;
 
 /**
- * CTRCipherOutputStream encrypts data. It is not thread-safe. AES CTR mode is
+ * CTRCryptoOutputStream encrypts data. It is not thread-safe. AES CTR mode is
  * required in order to ensure that the plain text and cipher text have a 1:1
  * mapping. The encryption is buffer based. The key points of the encryption are
  * (1) calculating counter and (2) padding through stream position.
@@ -49,7 +49,7 @@ import org.apache.commons.crypto.utils.Utils;
  * <p/>
  * The underlying stream offset is maintained as state.
  */
-public class CTRCipherOutputStream extends CipherOutputStream {
+public class CTRCryptoOutputStream extends CryptoOutputStream {
   /**
    * Underlying stream offset.
    */
@@ -78,7 +78,7 @@ public class CTRCipherOutputStream extends CipherOutputStream {
   private boolean cipherReset = false;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -87,14 +87,14 @@ public class CTRCipherOutputStream extends CipherOutputStream {
    * @param iv Initialization vector for the cipher.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherOutputStream(Properties props, OutputStream out, byte[] key,
+  public CTRCryptoOutputStream(Properties props, OutputStream out, byte[] key,
                                byte[] iv)
       throws IOException {
     this(props, out, key, iv, 0);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -103,60 +103,60 @@ public class CTRCipherOutputStream extends CipherOutputStream {
    * @param iv Initialization vector for the cipher.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherOutputStream(Properties props, WritableByteChannel out,
+  public CTRCryptoOutputStream(Properties props, WritableByteChannel out,
                                byte[] key, byte[] iv)
       throws IOException {
     this(props, out, key, iv, 0);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
    *
    * @param out the output stream.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherOutputStream(OutputStream out, Cipher cipher, int bufferSize,
+  public CTRCryptoOutputStream(OutputStream out, CryptoCipher cipher, int bufferSize,
                                byte[] key, byte[] iv) throws IOException {
     this(out, cipher, bufferSize, key, iv, 0);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
    *
    * @param channel the WritableByteChannel instance.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherOutputStream(WritableByteChannel channel, Cipher cipher,
+  public CTRCryptoOutputStream(WritableByteChannel channel, CryptoCipher cipher,
                                int bufferSize, byte[] key, byte[] iv) throws IOException {
     this(channel, cipher, bufferSize, key, iv, 0);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
    *
    * @param output the Output instance.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherOutputStream(Output output, Cipher cipher, int bufferSize,
+  public CTRCryptoOutputStream(Output output, CryptoCipher cipher, int bufferSize,
                                byte[] key, byte[] iv)
       throws IOException {
     this(output, cipher, bufferSize, key, iv, 0);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -166,7 +166,7 @@ public class CTRCipherOutputStream extends CipherOutputStream {
    * @param streamOffset the start offset in the data.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherOutputStream(Properties props, OutputStream out, byte[] key,
+  public CTRCryptoOutputStream(Properties props, OutputStream out, byte[] key,
                                byte[] iv, long streamOffset)
       throws IOException {
     this(out, Utils.getCipherInstance(CipherTransformation.AES_CTR_NOPADDING, props),
@@ -174,7 +174,7 @@ public class CTRCipherOutputStream extends CipherOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -184,7 +184,7 @@ public class CTRCipherOutputStream extends CipherOutputStream {
    * @param streamOffset the start offset in the data.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherOutputStream(Properties props, WritableByteChannel out,
+  public CTRCryptoOutputStream(Properties props, WritableByteChannel out,
                                byte[] key, byte[] iv, long streamOffset)
       throws IOException {
     this(out, Utils.getCipherInstance(CipherTransformation.AES_CTR_NOPADDING, props),
@@ -192,34 +192,34 @@ public class CTRCipherOutputStream extends CipherOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
    *
    * @param out the output stream.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @param streamOffset the start offset in the data.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherOutputStream(OutputStream out, Cipher cipher, int bufferSize,
+  public CTRCryptoOutputStream(OutputStream out, CryptoCipher cipher, int bufferSize,
                                byte[] key, byte[] iv, long streamOffset) throws IOException {
     this(new StreamOutput(out, bufferSize), cipher,
         bufferSize, key, iv, streamOffset);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
    *
    * @param channel the WritableByteChannel instance.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @param streamOffset the start offset in the data.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherOutputStream(WritableByteChannel channel, Cipher cipher,
+  public CTRCryptoOutputStream(WritableByteChannel channel, CryptoCipher cipher,
                                int bufferSize, byte[] key, byte[] iv,
                                long streamOffset) throws IOException {
     this(new ChannelOutput(channel), cipher,
@@ -227,17 +227,17 @@ public class CTRCipherOutputStream extends CipherOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
    *
    * @param output the output stream.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param iv Initialization vector for the cipher.
    * @param streamOffset the start offset in the data.
    * @throws IOException if an I/O error occurs.
    */
-  public CTRCipherOutputStream(Output output, Cipher cipher, int bufferSize,
+  public CTRCryptoOutputStream(Output output, CryptoCipher cipher, int bufferSize,
                                byte[] key, byte[] iv, long streamOffset)
       throws IOException {
     super(output, cipher, bufferSize, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
@@ -304,7 +304,7 @@ public class CTRCipherOutputStream extends CipherOutputStream {
   }
 
   /**
-   * Overrides the {@link CipherOutputStream#initCipher()}.
+   * Overrides the {@link CryptoOutputStream#initCipher()}.
    * Initializes the cipher.
    */
   @Override
@@ -327,7 +327,7 @@ public class CTRCipherOutputStream extends CipherOutputStream {
 
     Utils.calculateIV(initIV, counter, iv);
     try {
-      cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(iv));
+      cipher.init(CryptoCipher.ENCRYPT_MODE, key, new IvParameterSpec(iv));
     } catch (InvalidKeyException e) {
       throw new IOException(e);
     }catch (InvalidAlgorithmParameterException e) {
@@ -349,9 +349,9 @@ public class CTRCipherOutputStream extends CipherOutputStream {
       int n = cipher.update(inBuffer, out);
       if (n < inputSize) {
         /**
-         * Typically code will not get here. Cipher#update will consume all
+         * Typically code will not get here. CryptoCipher#update will consume all
          * input data and put result in outBuffer.
-         * Cipher#doFinal will reset the cipher context.
+         * CryptoCipher#doFinal will reset the cipher context.
          */
         cipher.doFinal(inBuffer, out);
         cipherReset = true;

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
@@ -32,7 +32,7 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 
-import org.apache.commons.crypto.cipher.Cipher;
+import org.apache.commons.crypto.cipher.CryptoCipher;
 import org.apache.commons.crypto.cipher.CipherTransformation;
 import org.apache.commons.crypto.stream.input.ChannelInput;
 import org.apache.commons.crypto.stream.input.Input;
@@ -45,12 +45,12 @@ import org.apache.commons.crypto.utils.Utils;
  *
  */
 
-public class CipherInputStream extends InputStream implements
+public class CryptoInputStream extends InputStream implements
     ReadableByteChannel {
   private final byte[] oneByteBuf = new byte[1];
 
-  /**The Cipher instance.*/
-  final Cipher cipher;
+  /**The CryptoCipher instance.*/
+  final CryptoCipher cipher;
 
   /**The buffer size.*/
   final int bufferSize;
@@ -83,7 +83,7 @@ public class CipherInputStream extends InputStream implements
   protected ByteBuffer outBuffer;
 
   /**
-   * Constructs a {@link CipherInputStream}.
+   * Constructs a {@link CryptoInputStream}.
    *
    * @param transformation the CipherTransformation instance.
    * @param props The <code>Properties</code> class represents a set of
@@ -93,7 +93,7 @@ public class CipherInputStream extends InputStream implements
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherInputStream(CipherTransformation transformation,
+  public CryptoInputStream(CipherTransformation transformation,
                            Properties props, InputStream in, Key key, AlgorithmParameterSpec params)
       throws IOException {
     this(in, Utils.getCipherInstance(transformation, props), Utils.getBufferSize(props), key,
@@ -101,7 +101,7 @@ public class CipherInputStream extends InputStream implements
   }
 
   /**
-   * Constructs a {@link CipherInputStream}.
+   * Constructs a {@link CryptoInputStream}.
    *
    * @param transformation the CipherTransformation instance.
    * @param props The <code>Properties</code> class represents a set of
@@ -111,7 +111,7 @@ public class CipherInputStream extends InputStream implements
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherInputStream(CipherTransformation transformation,
+  public CryptoInputStream(CipherTransformation transformation,
                            Properties props, ReadableByteChannel in, Key key, AlgorithmParameterSpec params)
       throws IOException {
     this(in, Utils.getCipherInstance(transformation, props),
@@ -119,7 +119,7 @@ public class CipherInputStream extends InputStream implements
   }
 
   /**
-   * Constructs a {@link CipherInputStream}.
+   * Constructs a {@link CryptoInputStream}.
    *
    * @param cipher the cipher instance.
    * @param in the input stream.
@@ -128,13 +128,13 @@ public class CipherInputStream extends InputStream implements
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherInputStream(InputStream in, Cipher cipher, int bufferSize,
+  public CryptoInputStream(InputStream in, CryptoCipher cipher, int bufferSize,
                            Key key, AlgorithmParameterSpec params) throws IOException {
     this(new StreamInput(in, bufferSize), cipher, bufferSize, key, params);
   }
 
   /**
-   * Constructs a {@link CipherInputStream}.
+   * Constructs a {@link CryptoInputStream}.
    *
    * @param in the ReadableByteChannel instance.
    * @param cipher the cipher instance.
@@ -143,13 +143,13 @@ public class CipherInputStream extends InputStream implements
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherInputStream(ReadableByteChannel in, Cipher cipher,
+  public CryptoInputStream(ReadableByteChannel in, CryptoCipher cipher,
                            int bufferSize, Key key, AlgorithmParameterSpec params) throws IOException {
     this(new ChannelInput(in), cipher, bufferSize, key, params);
   }
 
   /**
-   * Constructs a {@link CipherInputStream}.
+   * Constructs a {@link CryptoInputStream}.
    *
    * @param input the input data.
    * @param cipher the cipher instance.
@@ -158,7 +158,7 @@ public class CipherInputStream extends InputStream implements
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherInputStream(Input input, Cipher cipher, int bufferSize,
+  public CryptoInputStream(Input input, CryptoCipher cipher, int bufferSize,
                            Key key, AlgorithmParameterSpec params) throws IOException {
     this.input = input;
     this.cipher = cipher;
@@ -319,7 +319,7 @@ public class CipherInputStream extends InputStream implements
 
   /**
    * Overrides the {@link java.io.InputStream#mark(int)}.
-   * For {@link CipherInputStream},we don't support the mark method.
+   * For {@link CryptoInputStream},we don't support the mark method.
    *
    * @param readlimit the maximum limit of bytes that can be read before
    *                  the mark position becomes invalid.
@@ -330,7 +330,7 @@ public class CipherInputStream extends InputStream implements
 
   /**
    * Overrides the {@link InputStream#reset()}.
-   * For {@link CipherInputStream},we don't support the reset method.
+   * For {@link CryptoInputStream},we don't support the reset method.
    *
    * @throws IOException if an I/O error occurs.
    */
@@ -415,11 +415,11 @@ public class CipherInputStream extends InputStream implements
 
 
   /**
-   * Gets the internal Cipher.
+   * Gets the internal CryptoCipher.
    *
    * @return the cipher instance.
    */
-  protected Cipher getCipher() {
+  protected CryptoCipher getCipher() {
     return cipher;
   }
 
@@ -449,7 +449,7 @@ public class CipherInputStream extends InputStream implements
   protected void initCipher()
       throws IOException {
     try {
-      cipher.init(Cipher.DECRYPT_MODE, key, params);
+      cipher.init(CryptoCipher.DECRYPT_MODE, key, params);
     } catch (InvalidKeyException e) {
       throw new IOException(e);
     } catch(InvalidAlgorithmParameterException e) {

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
@@ -34,7 +34,7 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 
-import org.apache.commons.crypto.cipher.Cipher;
+import org.apache.commons.crypto.cipher.CryptoCipher;
 import org.apache.commons.crypto.cipher.CipherTransformation;
 import org.apache.commons.crypto.stream.output.ChannelOutput;
 import org.apache.commons.crypto.stream.output.Output;
@@ -42,20 +42,20 @@ import org.apache.commons.crypto.stream.output.StreamOutput;
 import org.apache.commons.crypto.utils.Utils;
 
 /**
- * {@link CipherOutputStream} encrypts data and writes to the under layer
+ * {@link CryptoOutputStream} encrypts data and writes to the under layer
  * output. It supports any mode of operations such as AES CBC/CTR/GCM mode
  * in concept. It is not thread-safe.
  */
 
-public class CipherOutputStream extends OutputStream implements
+public class CryptoOutputStream extends OutputStream implements
     WritableByteChannel {
   private final byte[] oneByteBuf = new byte[1];
 
   /** The output.*/
   Output output;
 
-  /**the Cipher instance*/
-  final Cipher cipher;
+  /**the CryptoCipher instance*/
+  final CryptoCipher cipher;
 
   /**The buffer size.*/
   final int bufferSize;
@@ -82,7 +82,7 @@ public class CipherOutputStream extends OutputStream implements
   ByteBuffer outBuffer;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CryptoOutputStream}.
    *
    * @param transformation the CipherTransformation instance.
    * @param props The <code>Properties</code> class represents a set of
@@ -92,18 +92,20 @@ public class CipherOutputStream extends OutputStream implements
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherOutputStream(
+
+
+  public CryptoOutputStream(
     CipherTransformation transformation,
     Properties props,
     OutputStream out,
     Key key,
     AlgorithmParameterSpec params) throws IOException {
-    this(out, Utils.getCipherInstance(transformation, props), Utils.getBufferSize(props), key,
-      params);
+    this(out, Utils.getCipherInstance(transformation, props), Utils.getBufferSize(props), key, params);
+
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CryptoOutputStream}.
    *
    * @param transformation the CipherTransformation instance.
    * @param props The <code>Properties</code> class represents a set of
@@ -113,33 +115,34 @@ public class CipherOutputStream extends OutputStream implements
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherOutputStream(
+  public CryptoOutputStream(
     CipherTransformation transformation,
     Properties props,
     WritableByteChannel out,
     Key key,
     AlgorithmParameterSpec params) throws IOException {
-    this(out, Utils.getCipherInstance(transformation, props), Utils.getBufferSize(props), key,
-      params);
+    this(out, Utils.getCipherInstance(transformation, props),
+        Utils.getBufferSize(props), key, params);
+
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CryptoOutputStream}.
    *
    * @param out the output stream.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherOutputStream(OutputStream out, Cipher cipher, int bufferSize,
+  public CryptoOutputStream(OutputStream out, CryptoCipher cipher, int bufferSize,
                             Key key, AlgorithmParameterSpec params) throws IOException {
     this(new StreamOutput(out, bufferSize), cipher, bufferSize, key, params);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CryptoOutputStream}.
    *
    * @param channel the WritableByteChannel instance.
    * @param cipher the cipher instance.
@@ -148,22 +151,22 @@ public class CipherOutputStream extends OutputStream implements
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  public CipherOutputStream(WritableByteChannel channel, Cipher cipher,
+  public CryptoOutputStream(WritableByteChannel channel, CryptoCipher cipher,
                             int bufferSize, Key key, AlgorithmParameterSpec params) throws IOException {
     this(new ChannelOutput(channel), cipher, bufferSize, key, params);
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CipherOutputStream}.
+   * Constructs a {@link org.apache.commons.crypto.stream.CryptoOutputStream}.
    *
    * @param output the output stream.
-   * @param cipher the Cipher instance.
+   * @param cipher the CryptoCipher instance.
    * @param bufferSize the bufferSize.
    * @param key crypto key for the cipher.
    * @param params the algorithm parameters.
    * @throws IOException if an I/O error occurs.
    */
-  protected CipherOutputStream(Output output, Cipher cipher, int bufferSize,
+  protected CryptoOutputStream(Output output, CryptoCipher cipher, int bufferSize,
                                Key key, AlgorithmParameterSpec params)
       throws IOException {
 
@@ -330,7 +333,7 @@ public class CipherOutputStream extends OutputStream implements
   protected void initCipher()
       throws IOException {
     try {
-      cipher.init(Cipher.ENCRYPT_MODE, key, params);
+      cipher.init(CryptoCipher.ENCRYPT_MODE, key, params);
     } catch (InvalidKeyException e) {
       throw new IOException(e);
     } catch(InvalidAlgorithmParameterException e) {
@@ -414,7 +417,7 @@ public class CipherOutputStream extends OutputStream implements
    *
    * @return the cipher instance.
    */
-  protected Cipher getCipher() {
+  protected CryptoCipher getCipher() {
     return cipher;
   }
 

--- a/src/main/java/org/apache/commons/crypto/stream/input/ChannelInput.java
+++ b/src/main/java/org/apache/commons/crypto/stream/input/ChannelInput.java
@@ -23,7 +23,7 @@ import java.nio.channels.ReadableByteChannel;
 
 /**
  * The ChannelInput class takes a <code>ReadableByteChannel</code> object and
- * wraps it as <code>Input</code> object acceptable by <code>CipherInputStream</code>.
+ * wraps it as <code>Input</code> object acceptable by <code>CryptoInputStream</code>.
  */
 public class ChannelInput implements Input {
   private static final int SKIP_BUFFER_SIZE = 2048;

--- a/src/main/java/org/apache/commons/crypto/stream/input/Input.java
+++ b/src/main/java/org/apache/commons/crypto/stream/input/Input.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * The Input interface abstract the input source of <code>CipherInputStream</code> so that
+ * The Input interface abstract the input source of <code>CryptoInputStream</code> so that
  * different implementation of input can be used. The implementation Input interface will usually
  * wraps an input mechanism such as <code>InputStream</code> or <code>ReadableByteChannel</code>.
  */

--- a/src/main/java/org/apache/commons/crypto/stream/input/StreamInput.java
+++ b/src/main/java/org/apache/commons/crypto/stream/input/StreamInput.java
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer;
 
 /**
  * The StreamInput class takes a <code>InputStream</code> object and
- * wraps it as <code>Input</code> object acceptable by <code>CipherInputStream</code>.
+ * wraps it as <code>Input</code> object acceptable by <code>CryptoInputStream</code>.
  */
 public class StreamInput implements Input {
   private byte[] buf;

--- a/src/main/java/org/apache/commons/crypto/stream/output/ChannelOutput.java
+++ b/src/main/java/org/apache/commons/crypto/stream/output/ChannelOutput.java
@@ -23,7 +23,7 @@ import java.nio.channels.WritableByteChannel;
 
 /**
  * The ChannelOutput class takes a <code>WritableByteChannel</code> object and wraps it as 
- * <code>Output</code> object acceptable by <code>CipherOutputStream</code> as the output target.
+ * <code>Output</code> object acceptable by <code>CryptoOutputStream</code> as the output target.
  */
 public class ChannelOutput implements Output {
 

--- a/src/main/java/org/apache/commons/crypto/stream/output/Output.java
+++ b/src/main/java/org/apache/commons/crypto/stream/output/Output.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * The Output interface abstract the output target of <code>CipherOutputStream</code> so that
+ * The Output interface abstract the output target of <code>CryptoOutputStream</code> so that
  * different implementation of output can be used. The implementation Output interface will usually
  * wraps an output mechanism such as <code>OutputStream</code> or <code>WritableByteChannel</code>.
  */

--- a/src/main/java/org/apache/commons/crypto/stream/output/StreamOutput.java
+++ b/src/main/java/org/apache/commons/crypto/stream/output/StreamOutput.java
@@ -22,8 +22,8 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 /**
- * The StreamOutput class takes a <code>OutputStream</code> object and wraps it as
- * <code>Output</code> object acceptable by <code>CipherOutputStream</code> as the output target.
+ * The StreamOutput class takes a <code>OutputStream</code> object and wraps it as 
+ * <code>Output</code> object acceptable by <code>CryptoOutputStream</code> as the output target.
  */
 public class StreamOutput implements Output {
   private byte[] buf;

--- a/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
-import org.apache.commons.crypto.cipher.Cipher;
+import org.apache.commons.crypto.cipher.CryptoCipher;
 
 /**
  * General utility methods for working with reflection.
@@ -37,7 +37,7 @@ public class ReflectionUtils {
   static {
     classLoader = Thread.currentThread().getContextClassLoader();
     if (classLoader == null) {
-      classLoader = Cipher.class.getClassLoader();
+      classLoader = CryptoCipher.class.getClassLoader();
     }
   }
 
@@ -51,7 +51,7 @@ public class ReflectionUtils {
 
   /**
    * A unique class which is used as a sentinel value in the caching
-   * for getClassByName. {@link Cipher#getClassByNameOrNull(String)}.
+   * for getClassByName. {@link CryptoCipher#getClassByNameOrNull(String)}.
    */
   private static abstract class NegativeCacheSentinel {}
 

--- a/src/main/java/org/apache/commons/crypto/utils/Utils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/Utils.java
@@ -26,8 +26,8 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.commons.crypto.cipher.Cipher;
-import org.apache.commons.crypto.cipher.CipherFactory;
+import org.apache.commons.crypto.cipher.CryptoCipher;
+import org.apache.commons.crypto.cipher.CryptoCipherFactory;
 import org.apache.commons.crypto.cipher.CipherTransformation;
 import org.apache.commons.crypto.conf.ConfigurationKeys;
 
@@ -209,10 +209,10 @@ public class Utils {
   /**
    * Checks whether the cipher is supported streaming.
    *
-   * @param cipher the {@link org.apache.commons.crypto.cipher.Cipher} instance.
+   * @param cipher the {@link CryptoCipher} instance.
    * @throws IOException if an I/O error occurs.
    */
-  public static void checkStreamCipher(Cipher cipher) throws IOException {
+  public static void checkStreamCipher(CryptoCipher cipher) throws IOException {
     if (cipher.getTransformation() != CipherTransformation.AES_CTR_NOPADDING) {
       throw new IOException("AES/CTR/NoPadding is required");
     }
@@ -221,11 +221,11 @@ public class Utils {
   /**
    * Checks and floors buffer size.
    *
-   * @param cipher the {@link org.apache.commons.crypto.cipher.Cipher} instance.
+   * @param cipher the {@link CryptoCipher} instance.
    * @param bufferSize the buffer size.
    * @return the remaining buffer size.
    */
-  public static int checkBufferSize(Cipher cipher, int bufferSize) {
+  public static int checkBufferSize(CryptoCipher cipher, int bufferSize) {
     checkArgument(bufferSize >= MIN_BUFFER_SIZE,
         "Minimum value of buffer size is " + MIN_BUFFER_SIZE + ".");
     return bufferSize - bufferSize % cipher.getTransformation()
@@ -233,10 +233,10 @@ public class Utils {
   }
 
   /**
-   * This method is only for Counter (CTR) mode. Generally the Cipher calculates the
+   * This method is only for Counter (CTR) mode. Generally the CryptoCipher calculates the
    * IV and maintain encryption context internally.For example a
    * {@link javax.crypto.Cipher} will maintain its encryption context internally
-   * when we do encryption/decryption using the Cipher#update interface.
+   * when we do encryption/decryption using the CryptoCipher#update interface.
    * <p/>
    * Encryption/Decryption is not always on the entire file. For example,
    * in Hadoop, a node may only decrypt a portion of a file (i.e. a split).
@@ -269,18 +269,18 @@ public class Utils {
   }
 
   /**
-   * Helper method to create a Cipher instance and throws only IOException.
+   * Helper method to create a CryptoCipher instance and throws only IOException.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
    * @param transformation the CipherTransformation instance.
-   * @return the Cipher instance.
+   * @return the CryptoCipher instance.
    * @throws IOException if an I/O error occurs.
    */
-  public static Cipher getCipherInstance(CipherTransformation transformation,
-      Properties props) throws IOException {
+  public static CryptoCipher getCipherInstance(CipherTransformation transformation,
+                                               Properties props) throws IOException {
     try {
-      return CipherFactory.getInstance(transformation, props);
+      return CryptoCipherFactory.getInstance(transformation, props);
     } catch (GeneralSecurityException e) {
       throw new IOException(e);
     }

--- a/src/main/native/org/apache/commons/crypto/random/OpensslCryptoRandomNative.c
+++ b/src/main/native/org/apache/commons/crypto/random/OpensslCryptoRandomNative.c
@@ -33,7 +33,7 @@
 #include <windows.h>
 #endif
 
-#include "OpensslSecureRandomNative.h"
+#include "OpensslCryptoRandomNative.h"
 
 #ifdef UNIX
 static void * (*dlsym_CRYPTO_malloc) (int, const char *, int);
@@ -86,7 +86,7 @@ static ENGINE * openssl_rand_init(void);
 static void openssl_rand_clean(ENGINE *eng, int clean_locks);
 static int openssl_rand_bytes(unsigned char *buf, int num);
 
-JNIEXPORT void JNICALL Java_org_apache_commons_crypto_random_OpensslSecureRandomNative_initSR
+JNIEXPORT void JNICALL Java_org_apache_commons_crypto_random_OpensslCryptoRandomNative_initSR
     (JNIEnv *env, jclass clazz)
 {
   char msg[1000];
@@ -160,7 +160,7 @@ JNIEXPORT void JNICALL Java_org_apache_commons_crypto_random_OpensslSecureRandom
   openssl_rand_init();
 }
 
-JNIEXPORT jboolean JNICALL Java_org_apache_commons_crypto_random_OpensslSecureRandomNative_nextRandBytes___3B
+JNIEXPORT jboolean JNICALL Java_org_apache_commons_crypto_random_OpensslCryptoRandomNative_nextRandBytes___3B
     (JNIEnv *env, jobject object, jbyteArray bytes)
 {
   if (NULL == bytes) {

--- a/src/site/xdoc/userguide.xml
+++ b/src/site/xdoc/userguide.xml
@@ -32,7 +32,7 @@
               </a>
             </td>
             <td>
-              The interface for SecureRandom.
+              The interface for CryptoRandom.
             </td>
           </tr>
           <tr>
@@ -62,7 +62,7 @@
         <ol style="list-style-type: decimal">
         <h4>Usage of Random API</h4>
         <p>
-          SecureRandom provides a cryptographically strong random number generators.
+          CryptoRandom provides a cryptographically strong random number generators.
           The default implementation will use Intel® Digital Random Number Generator (DRNG)
           for accelerating the random generation.
         </p>
@@ -73,13 +73,13 @@
               byte[] key = new byte[16];<br/>
               byte[] iv = new byte[16];<br/>
               Properties properties = new Properties();<br/>
-              //Gets the 'SecureRandom' instance.<br/>
-              SecureRandom secureRandom = SecureRandomFactory.getSecureRandom(properties);<br/>
+              //Gets the 'CryptoRandom' instance.<br/>
+              CryptoRandom CryptoRandom = CryptoRandomFactory.getCryptoRandom(properties);<br/>
               //Generates random bytes and places them into the byte array.<br/>
-              secureRandom.nextBytes(key);<br/>
-              secureRandom.nextBytes(iv);<br/>
-              //Closes the SecureRandom.<br/>
-              secureRandom.close();<br/>
+              CryptoRandom.nextBytes(key);<br/>
+              CryptoRandom.nextBytes(iv);<br/>
+              //Closes the CryptoRandom.<br/>
+              CryptoRandom.close();<br/>
             </td>
           </tr>
         </table>
@@ -96,8 +96,8 @@
           <tr>
             <td>
               Properties properties = new Properties();<br/>
-              //Creates a Cipher instance with the transformation and properties.<br/>
-              Cipher cipher = Utils.getCipherInstance(CipherTransformation.AES_CTR_NOPADDING, properties);<br/><br/>
+              //Creates a CryptoCipher instance with the transformation and properties.<br/>
+              CryptoCipher cipher = Utils.getCipherInstance(CipherTransformation.AES_CTR_NOPADDING, properties);<br/><br/>
               String input = "hello world!";<br/>
               int inputOffset = 0;<br/>
               int inputLen = input.length();<br/>
@@ -121,7 +121,7 @@
             <td>
               Properties properties = new Properties();<br/>
               //Creates a Cipher instance with the transformation and properties.<br/>
-              Cipher cipher = Utils.getCipherInstance(CipherTransformation.AES_CTR_NOPADDING, properties);<br/><br/>
+              CryptoCipher cipher = Utils.getCipherInstance(CipherTransformation.AES_CTR_NOPADDING, properties);<br/><br/>
               int bufferSize = 4096;<br/>
               ByteBuffer inBuffer = ByteBuffer.allocateDirect(bufferSize);<br/>
               ByteBuffer outBuffer = ByteBuffer.allocateDirect(bufferSize);<br/>
@@ -140,9 +140,9 @@
 
         <h4>Usage of Stream API</h4>
         <p>
-          Stream provides the data encryption and decryption in stream manner. We provide CipherInputStream,
-          CTRCipherInputStream, PositionedCipherInputstream implementations for InputStream and CipherOutputStream,
-          CTRCipherOutputStream implementations for OutputStream.
+          Stream provides the data encryption and decryption in stream manner. We provide CryptoInputStream,
+          CTRCryptoInputStream, PositionedCryptoInputStream implementations for InputStream and CryptoOutputStream,
+          CTRCryptoOutputStream implementations for OutputStream.
         </p>
         <h5>Usage of stream encryption</h5>
         <table>
@@ -151,13 +151,13 @@
               int bufferSize = 4096;<br/>
               String input = "hello world!";<br/>
               byte[] decryptedData = new byte[1024];<br/>
-              //Encryption with CipherOutputStream.<br/>
+              //Encryption with CryptoOutputStream.<br/>
               //Initializes the cipher with ENCRYPT_MODE,key and iv.<br/>
               cipher.init(Cipher.ENCRYPT_MODE, key, iv);<br/>
               // Constructs the original OutputStream.<br/>
               OutputStream outputStream = new ByteArrayOutputStream();<br/>
-              //Constructs the instance of CipherOutputStream.<br/>
-              CipherOutputStream cos = new CipherOutputStream(outputStream, cipher, bufferSize, key, iv);<br/>
+              //Constructs the instance of CryptoOutputStream.<br/>
+              CryptoOutputStream cos = new CryptoOutputStream(outputStream, cipher, bufferSize, key, iv);<br/>
               cos.write(input.getBytes("UTF-8"));<br/>
               cos.flush();<br/>
               cos.close();<br/>
@@ -168,13 +168,13 @@
         <table>
           <tr>
             <td>
-              // Decryption with CipherInputStream.<br/>
+              // Decryption with CryptoInputStream.<br/>
               //Initializes the cipher with DECRYPT_MODE,key and iv.<br/>
               cipher.init(Cipher.DECRYPT_MODE, key, iv);<br/>
               //Constructs the original InputStream.<br/>
               InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());<br/>
-              //Constructs the instance of CipherInputStream.<br/>
-              CipherInputStream cis = new CipherInputStream(inputStream, cipher, bufferSize, key, iv);<br/>
+              //Constructs the instance of CryptoInputStream.<br/>
+              CryptoInputStream cis = new CryptoInputStream(inputStream, cipher, bufferSize, key, iv);<br/>
               int decryptedLen = cis.read(decryptedData, 0, 1024);<br/>
               cis.close();<br/>
             </td>

--- a/src/test/java/org/apache/commons/crypto/cipher/AbstractCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/AbstractCipherTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractCipherTest {
       0x07, 0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16};
   static final byte[] IV = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
       0x07, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-  Cipher enc, dec;
+  CryptoCipher enc, dec;
 
   @Before
   public void setup() {
@@ -96,19 +96,19 @@ public abstract class AbstractCipherTest {
       GeneralSecurityException, IOException {
     ByteBuffer decResult = ByteBuffer.allocateDirect(BYTEBUFFER_SIZE);
     ByteBuffer encResult = ByteBuffer.allocateDirect(BYTEBUFFER_SIZE);
-    Cipher enc, dec;
+    CryptoCipher enc, dec;
 
     enc = getCipher(transformation);
     dec = getCipher(transformation);
 
     try {
-      enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
+      enc.init(CryptoCipher.ENCRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     } catch (Exception e) {
       Assert.fail("AES failed initialisation - " + e.toString());
     }
 
     try {
-      dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
+      dec.init(CryptoCipher.DECRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     } catch (Exception e) {
       Assert.fail("AES failed initialisation - " + e.toString());
     }
@@ -219,21 +219,21 @@ public abstract class AbstractCipherTest {
     dec = getCipher(transformation);
 
     try {
-      enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
+      enc.init(CryptoCipher.ENCRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     } catch (Exception e) {
       Assert.fail("AES failed initialisation - " + e.toString());
     }
 
     try {
-      dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
+      dec.init(CryptoCipher.DECRYPT_MODE, new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     } catch (Exception e) {
       Assert.fail("AES failed initialisation - " + e.toString());
     }
   }
 
-  private Cipher getCipher(CipherTransformation transformation) {
+  private CryptoCipher getCipher(CipherTransformation transformation) {
     try {
-      return (Cipher) ReflectionUtils
+      return (CryptoCipher) ReflectionUtils
           .newInstance(ReflectionUtils.getClassByName(cipherClass), props,
               transformation);
     } catch (ClassNotFoundException e) {

--- a/src/test/java/org/apache/commons/crypto/cipher/CryptoCipherFactoryTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/CryptoCipherFactoryTest.java
@@ -25,10 +25,10 @@ import org.apache.commons.crypto.conf.ConfigurationKeys;
 import junit.framework.Assert;
 import org.junit.Test;
 
-public class CipherFactoryTest {
+public class CryptoCipherFactoryTest {
   @Test
   public void testDefaultCipher() throws GeneralSecurityException {
-    Cipher defaultCipher = CipherFactory.getInstance(
+    CryptoCipher defaultCipher = CryptoCipherFactory.getInstance(
         CipherTransformation.AES_CBC_NOPADDING);
     Assert.assertEquals(OpensslCipher.class.getName(),
         defaultCipher.getClass().getName());
@@ -38,7 +38,7 @@ public class CipherFactoryTest {
   public void testEmptyCipher() throws GeneralSecurityException {
     Properties properties = new Properties();
     properties.put(ConfigurationKeys.COMMONS_CRYPTO_CIPHER_CLASSES_KEY, "");
-    Cipher defaultCipher = CipherFactory.getInstance(
+    CryptoCipher defaultCipher = CryptoCipherFactory.getInstance(
         CipherTransformation.AES_CBC_NOPADDING, properties);
     Assert.assertEquals(OpensslCipher.class.getName(),
         defaultCipher.getClass().getName());
@@ -49,7 +49,7 @@ public class CipherFactoryTest {
     Properties properties = new Properties();
     properties.put(ConfigurationKeys.COMMONS_CRYPTO_CIPHER_CLASSES_KEY,
         "InvalidCipherName");
-    Cipher defaultCipher = CipherFactory.getInstance(
+    CryptoCipher defaultCipher = CryptoCipherFactory.getInstance(
         CipherTransformation.AES_CBC_NOPADDING, properties);
     Assert.assertEquals(JceCipher.class.getName(),
         defaultCipher.getClass().getName());

--- a/src/test/java/org/apache/commons/crypto/random/AbstractRandomTest.java
+++ b/src/test/java/org/apache/commons/crypto/random/AbstractRandomTest.java
@@ -24,11 +24,11 @@ import org.junit.Test;
 
 public abstract class AbstractRandomTest {
 
-  public abstract SecureRandom getSecureRandom() throws GeneralSecurityException;
+  public abstract CryptoRandom getCryptoRandom() throws GeneralSecurityException;
 
   @Test(timeout=120000)
   public void testRandomBytes() throws Exception {
-    SecureRandom random = getSecureRandom();
+    CryptoRandom random = getCryptoRandom();
     // len = 16
     checkRandomBytes(random, 16);
     // len = 32
@@ -44,7 +44,7 @@ public abstract class AbstractRandomTest {
    * Test will timeout if secure random implementation always returns a
    * constant value.
    */
-  private void checkRandomBytes(SecureRandom random, int len) {
+  private void checkRandomBytes(CryptoRandom random, int len) {
     byte[] bytes = new byte[len];
     byte[] bytes1 = new byte[len];
     random.nextBytes(bytes);

--- a/src/test/java/org/apache/commons/crypto/random/TestJavaCryptoRandom.java
+++ b/src/test/java/org/apache/commons/crypto/random/TestJavaCryptoRandom.java
@@ -17,20 +17,24 @@
  */
 package org.apache.commons.crypto.random;
 
-import java.io.Closeable;
+import java.security.GeneralSecurityException;
+import java.util.Properties;
 
-/**
- * The interface for SecureRandom.
- */
-public interface SecureRandom extends Closeable {
+import org.apache.commons.crypto.conf.ConfigurationKeys;
+import static junit.framework.Assert.fail;
 
-  /**
-   * Generates random bytes and places them into a user-supplied
-   * byte array.  The number of random bytes produced is equal to
-   * the length of the byte array.
-   *
-   * @param bytes the byte array to fill with random bytes
-   */
-  void nextBytes(byte[] bytes);
+public class TestJavaCryptoRandom extends AbstractRandomTest {
+
+  @Override
+  public CryptoRandom getCryptoRandom() throws GeneralSecurityException {
+    Properties props = new Properties();
+    props.setProperty(ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY,
+        JavaCryptoRandom.class.getName());
+    CryptoRandom random = CryptoRandomFactory.getCryptoRandom(props);
+    if ( !(random instanceof JavaCryptoRandom)) {
+      fail("The CryptoRandom should be: " + JavaCryptoRandom.class.getName());
+    }
+    return random;
+  }
 
 }

--- a/src/test/java/org/apache/commons/crypto/random/TestOpensslCryptoRandom.java
+++ b/src/test/java/org/apache/commons/crypto/random/TestOpensslCryptoRandom.java
@@ -17,12 +17,24 @@
  */
 package org.apache.commons.crypto.random;
 
+import java.security.GeneralSecurityException;
 import java.util.Properties;
 
-public class TestOsSecureRandom extends AbstractRandomTest{
+import org.apache.commons.crypto.conf.ConfigurationKeys;
+import static junit.framework.Assert.fail;
+
+public class TestOpensslCryptoRandom extends AbstractRandomTest {
 
   @Override
-  public SecureRandom getSecureRandom() {
-    return new OsSecureRandom(new Properties());
+  public CryptoRandom getCryptoRandom() throws GeneralSecurityException {
+    Properties props = new Properties();
+    props.setProperty(ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY,
+        OpensslCryptoRandom.class.getName());
+    CryptoRandom random = CryptoRandomFactory.getCryptoRandom(props);
+    if ( !(random instanceof OpensslCryptoRandom)) {
+      fail("The CryptoRandom should be: " + OpensslCryptoRandom.class.getName());
+    }
+    return random;
   }
+
 }

--- a/src/test/java/org/apache/commons/crypto/random/TestOsCryptoRandom.java
+++ b/src/test/java/org/apache/commons/crypto/random/TestOsCryptoRandom.java
@@ -17,24 +17,12 @@
  */
 package org.apache.commons.crypto.random;
 
-import java.security.GeneralSecurityException;
 import java.util.Properties;
 
-import org.apache.commons.crypto.conf.ConfigurationKeys;
-import static junit.framework.Assert.fail;
-
-public class TestJavaSecureRandom extends AbstractRandomTest {
+public class TestOsCryptoRandom extends AbstractRandomTest{
 
   @Override
-  public SecureRandom getSecureRandom() throws GeneralSecurityException {
-    Properties props = new Properties();
-    props.setProperty(ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_CLASSES_KEY,
-        JavaSecureRandom.class.getName());
-    SecureRandom random = SecureRandomFactory.getSecureRandom(props);
-    if ( !(random instanceof JavaSecureRandom)) {
-      fail("The SecureRandom should be: " + JavaSecureRandom.class.getName());
-    }
-    return random;
+  public CryptoRandom getCryptoRandom() {
+    return new OsCryptoRandom(new Properties());
   }
-
 }

--- a/src/test/java/org/apache/commons/crypto/stream/CTRCryptoStreamTest.java
+++ b/src/test/java/org/apache/commons/crypto/stream/CTRCryptoStreamTest.java
@@ -22,10 +22,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 
-import org.apache.commons.crypto.cipher.Cipher;
+import org.apache.commons.crypto.cipher.CryptoCipher;
 import org.apache.commons.crypto.cipher.CipherTransformation;
 
-public class CTRCipherStreamTest extends AbstractCipherStreamTest {
+public class CTRCryptoStreamTest extends AbstractCipherStreamTest {
 
   @Override
 public void setUp() throws IOException {
@@ -34,26 +34,26 @@ public void setUp() throws IOException {
   }
 
   @Override
-  protected CTRCipherInputStream getCipherInputStream
-      (ByteArrayInputStream bais, Cipher cipher, int
-      bufferSize,byte[] iv, boolean withChannel)
+  protected CTRCryptoInputStream getCryptoInputStream
+      (ByteArrayInputStream bais, CryptoCipher cipher, int
+      bufferSize, byte[] iv, boolean withChannel)
       throws IOException {
     if (withChannel) {
-      return new CTRCipherInputStream(Channels.newChannel(bais), cipher,
+      return new CTRCryptoInputStream(Channels.newChannel(bais), cipher,
           bufferSize, key, iv);
     } else {
-      return new CTRCipherInputStream(bais, cipher, bufferSize, key, iv);
+      return new CTRCryptoInputStream(bais, cipher, bufferSize, key, iv);
     }
   }
 
   @Override
-  protected CTRCipherOutputStream getCipherOutputStream(ByteArrayOutputStream baos, Cipher cipher, int
-      bufferSize, byte[] iv, boolean withChannel)
+  protected CTRCryptoOutputStream getCryptoOutputStream(ByteArrayOutputStream baos, CryptoCipher cipher,
+                                                        int bufferSize, byte[] iv, boolean withChannel)
       throws IOException {
     if (withChannel) {
-      return new CTRCipherOutputStream(Channels.newChannel(baos), cipher, bufferSize, key, iv);
+      return new CTRCryptoOutputStream(Channels.newChannel(baos), cipher, bufferSize, key, iv);
     } else {
-      return new CTRCipherOutputStream(baos, cipher, bufferSize, key, iv);
+      return new CTRCryptoOutputStream(baos, cipher, bufferSize, key, iv);
     }
   }
 }

--- a/src/test/java/org/apache/commons/crypto/stream/PositionedCryptoInputStreamTest.java
+++ b/src/test/java/org/apache/commons/crypto/stream/PositionedCryptoInputStreamTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.commons.crypto.stream;
 
-import org.apache.commons.crypto.cipher.Cipher;
+import org.apache.commons.crypto.cipher.CryptoCipher;
 import org.apache.commons.crypto.cipher.CipherTransformation;
 import org.apache.commons.crypto.cipher.JceCipher;
 import org.apache.commons.crypto.cipher.OpensslCipher;
@@ -39,7 +39,7 @@ import java.util.Arrays;
 import java.util.Properties;
 import java.util.Random;
 
-public class PositionedCipherInputStreamTest {
+public class PositionedCryptoInputStreamTest {
 
   private final int dataLen = 20000;
   private byte[] testData = new byte[dataLen];
@@ -69,9 +69,9 @@ public class PositionedCipherInputStreamTest {
   }
 
   private void prepareData() throws IOException {
-    Cipher cipher = null;
+    CryptoCipher cipher = null;
     try {
-      cipher = (Cipher)ReflectionUtils.newInstance(
+      cipher = (CryptoCipher)ReflectionUtils.newInstance(
               ReflectionUtils.getClassByName(jceCipherClass),
               props, transformation);
     } catch (ClassNotFoundException cnfe) {
@@ -80,7 +80,7 @@ public class PositionedCipherInputStreamTest {
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     // encryption data
-    OutputStream out = new CipherOutputStream(baos, cipher, bufferSize,
+    OutputStream out = new CryptoOutputStream(baos, cipher, bufferSize,
             new SecretKeySpec(key,"AES"), new IvParameterSpec(iv));
     out.write(testData);
     out.flush();
@@ -90,9 +90,9 @@ public class PositionedCipherInputStreamTest {
 
   public void setUp() throws IOException {}
 
-  private PositionedCipherInputStream getCipherInputStream(Cipher cipher,
+  private PositionedCryptoInputStream getCryptoInputStream(CryptoCipher cipher,
                                                            int bufferSize) throws IOException {
-    return new PositionedCipherInputStream(new PositionedInputForTest(
+    return new PositionedCryptoInputStream(new PositionedInputForTest(
       Arrays.copyOf(encData, encData.length)), cipher, bufferSize, key, iv, 0);
   }
 
@@ -112,7 +112,7 @@ public class PositionedCipherInputStreamTest {
   // when there are multiple positioned read actions and one read action,
   // they will not interfere each other.
   private void doMultipleReadTest(String cipherClass) throws Exception {
-    PositionedCipherInputStream in = getCipherInputStream(
+    PositionedCryptoInputStream in = getCryptoInputStream(
             getCipher(cipherClass), bufferSize);
     int position = 0;
     while (in.available() > 0) {
@@ -187,7 +187,7 @@ public class PositionedCipherInputStreamTest {
 
   private void testSeekLoop(String cipherClass, int position, int length,
       int bufferSize) throws Exception {
-    PositionedCipherInputStream in = getCipherInputStream(
+    PositionedCryptoInputStream in = getCryptoInputStream(
             getCipher(cipherClass), bufferSize);
     while (in.available() > 0) {
       in.seek(position);
@@ -206,7 +206,7 @@ public class PositionedCipherInputStreamTest {
   // test for the out of index position, eg, -1.
   private void testSeekFailed(String cipherClass, int position,
       int bufferSize) throws Exception {
-    PositionedCipherInputStream in = getCipherInputStream(
+    PositionedCryptoInputStream in = getCryptoInputStream(
             getCipher(cipherClass), bufferSize);
     try {
       in.seek(position);
@@ -218,7 +218,7 @@ public class PositionedCipherInputStreamTest {
 
   private void testPositionedReadLoop(String cipherClass, int position,
       int length, int bufferSize, int total) throws Exception {
-    PositionedCipherInputStream in = getCipherInputStream(
+    PositionedCryptoInputStream in = getCryptoInputStream(
             getCipher(cipherClass), bufferSize);
     // do the position read until the end of data
     while (position < total) {
@@ -237,7 +237,7 @@ public class PositionedCipherInputStreamTest {
   // test for the out of index position, eg, -1.
   private void testPositionedReadNone(String cipherClass, int position,
       int length, int bufferSize) throws Exception {
-    PositionedCipherInputStream in = getCipherInputStream(
+    PositionedCryptoInputStream in = getCryptoInputStream(
             getCipher(cipherClass), bufferSize);
     byte[] bytes = new byte[length];
     int n = in.read(position, bytes, 0, length);
@@ -247,7 +247,7 @@ public class PositionedCipherInputStreamTest {
 
   private void testReadFullyLoop(String cipherClass,int position,
       int length, int bufferSize, int total) throws Exception {
-    PositionedCipherInputStream in = getCipherInputStream(
+    PositionedCryptoInputStream in = getCryptoInputStream(
             getCipher(cipherClass), bufferSize);
 
     // do the position read full until remain < length
@@ -264,7 +264,7 @@ public class PositionedCipherInputStreamTest {
   // test for the End of file reached before reading fully
   private void testReadFullyFailed(String cipherClass, int position,
       int length, int bufferSize) throws Exception {
-    PositionedCipherInputStream in = getCipherInputStream(
+    PositionedCryptoInputStream in = getCryptoInputStream(
             getCipher(cipherClass), bufferSize);
     byte[] bytes = new byte[length];
     try {
@@ -287,9 +287,9 @@ public class PositionedCipherInputStreamTest {
     Assert.assertArrayEquals(expectedData, realData);
   }
 
-  private Cipher getCipher(String cipherClass) throws IOException {
+  private CryptoCipher getCipher(String cipherClass) throws IOException {
     try {
-      return (Cipher)ReflectionUtils.newInstance(
+      return (CryptoCipher)ReflectionUtils.newInstance(
           ReflectionUtils.getClassByName(cipherClass), props, transformation);
     } catch (ClassNotFoundException cnfe) {
       throw new IOException("Illegal crypto cipher!");


### PR DESCRIPTION
renaming Cipher/Stream/Random classes  ([CRYPTO-33](https://issues.apache.org/jira/browse/CRYPTO-33))

0. Cipher classes:
Cipher  -> CryptoCipher
CipherFactory -> CryptoCipherFactory

1. Stream classes:
CipherInputStream    ->     CrytoInputStream
CipherOutputStream   ->       CrytoOutputStream
CTRCipherInputStream   ->     CTRCrytoInputStream  
CTRCipherInputStream   ->     CTRCrytoOutputStream  
PostionedCipherInputStream -> PostionedCrytoInputStream 

2. Random classes:
SecureRandom ->  CryptoRandom.java
SecureRandomFactory  ->  CryptoRandomFactory
JavaSecureRandom ->  JavaCryptoRandom
OpensslSecureRandom  ->  OpensslCryptoRandom
OpensslSecureRandomNative OpensslCryptoRandomNative
OsSecureRandom -> OsCryptoRandom
TestJavaSecureRandom -> TestJavaCryptoRandom
TestOpensslSecureRandom -> TestOpensslCryptoRandom
TestOsSecureRandom -> TestOsCryptoRandom

OpensslSecureRandomNative.c -> OpensslCryptoRandomNative.c

3. function names & Makefile script