### PR TITLE
CRYPTO-40:Remove the full qualified package name for shadowed classes

### DIFF
--- a/src/main/java/org/apache/commons/crypto/cipher/CipherTransformation.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/CipherTransformation.java
@@ -19,7 +19,7 @@ package org.apache.commons.crypto.cipher;
 
 /**
  * Defines properties of a CipherTransformation. Modeled after the ciphers in
- * {@link javax.crypto.Cipher}.
+ * {@link Cipher}.
  */
 public enum CipherTransformation {
 
@@ -48,7 +48,7 @@ public enum CipherTransformation {
   /**
    * Gets the algorithm name of cipher.
    *
-   * @return name of cipher transformation, as in {@link javax.crypto.Cipher}
+   * @return name of cipher transformation, as in {@link Cipher}
    */
   public String getName() {
     return name;

--- a/src/main/java/org/apache/commons/crypto/cipher/CryptoCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/CryptoCipher.java
@@ -26,6 +26,7 @@ import java.security.spec.AlgorithmParameterSpec;
 import java.util.Properties;
 
 import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.ShortBufferException;
 
@@ -38,13 +39,13 @@ public interface CryptoCipher extends Closeable {
    * A constant representing encrypt mode.  The mode constant to be used
    * when calling init method of the CryptoCipher.
    */
-  int ENCRYPT_MODE = javax.crypto.Cipher.ENCRYPT_MODE;
+  int ENCRYPT_MODE = Cipher.ENCRYPT_MODE;
 
   /**
    * A constant representing decrypt mode.  The mode constant to be used
    * when calling init method of the CryptoCipher.
    */
-  int DECRYPT_MODE = javax.crypto.Cipher.DECRYPT_MODE;
+  int DECRYPT_MODE = Cipher.DECRYPT_MODE;
 
   /**
    * Gets the CipherTransformation for this cipher.

--- a/src/main/java/org/apache/commons/crypto/cipher/JceCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/JceCipher.java
@@ -26,22 +26,23 @@ import java.security.spec.AlgorithmParameterSpec;
 import java.util.Properties;
 
 import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.ShortBufferException;
 
 import org.apache.commons.crypto.utils.Utils;
 
 /**
- * Implements the {@link org.apache.commons.crypto.cipher.CryptoCipher} using JCE provider.
+ * Implements the {@link CryptoCipher} using JCE provider.
  */
 public class JceCipher implements CryptoCipher {
   private final Properties props;
   private final CipherTransformation transformation;
-  private final javax.crypto.Cipher cipher;
+  private final Cipher cipher;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.cipher.CryptoCipher} based on JCE
-   * Cipher {@link javax.crypto.Cipher}.
+   * Constructs a {@link CryptoCipher} based on JCE
+   * Cipher {@link Cipher}.
    * @param props properties for JCE cipher
    * @param transformation transformation for JCE cipher
    * @throws GeneralSecurityException if JCE cipher initialize failed
@@ -53,9 +54,9 @@ public class JceCipher implements CryptoCipher {
 
     String provider = Utils.getJCEProvider(props);
     if (provider == null || provider.isEmpty()) {
-      cipher = javax.crypto.Cipher.getInstance(transformation.getName());
+      cipher = Cipher.getInstance(transformation.getName());
     } else {
-      cipher = javax.crypto.Cipher.getInstance(transformation.getName(), provider);
+      cipher = Cipher.getInstance(transformation.getName(), provider);
     }
   }
 
@@ -98,9 +99,9 @@ public class JceCipher implements CryptoCipher {
     Utils.checkNotNull(key);
     Utils.checkNotNull(params);
 
-    int cipherMode = javax.crypto.Cipher.DECRYPT_MODE;
+    int cipherMode = Cipher.DECRYPT_MODE;
     if (mode == ENCRYPT_MODE) {
-      cipherMode = javax.crypto.Cipher.ENCRYPT_MODE;
+      cipherMode = Cipher.ENCRYPT_MODE;
     }
     cipher.init(cipherMode, key, params);
   }

--- a/src/main/java/org/apache/commons/crypto/cipher/OpensslCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpensslCipher.java
@@ -42,7 +42,7 @@ public class OpensslCipher implements CryptoCipher {
   private final Openssl cipher;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.cipher.CryptoCipher} using JNI into OpenSSL
+   * Constructs a {@link CryptoCipher} using JNI into OpenSSL
    *
    * @param props properties for OpenSSL cipher
    * @param transformation transformation for OpenSSL cipher

--- a/src/main/java/org/apache/commons/crypto/conf/ConfigurationKeys.java
+++ b/src/main/java/org/apache/commons/crypto/conf/ConfigurationKeys.java
@@ -42,7 +42,7 @@ public class ConfigurationKeys {
    * "org.apache.commons.crypto.cipher.JceCipher" and "org.apache.commons.crypto.cipher.OpensslCipher".
    * And it takes a common separated list.
    * The "org.apache.commons.crypto.cipher.JceCipher" use jce provider to
-   * implement {@link org.apache.commons.crypto.cipher.CryptoCipher} and
+   * implement {@link CryptoCipher} and
    * the "org.apache.commons.crypto.cipher.OpensslCipher" use jni into openssl to implement.
    * Note that for each value,the first value which can be created without exception
    * will be used (priority by order).

--- a/src/main/java/org/apache/commons/crypto/random/JavaCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/JavaCryptoRandom.java
@@ -18,6 +18,7 @@
 package org.apache.commons.crypto.random;
 
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Properties;
 
 import org.apache.commons.logging.Log;
@@ -32,17 +33,17 @@ public class JavaCryptoRandom implements CryptoRandom {
   private static final Log LOG =
       LogFactory.getLog(JavaCryptoRandom.class.getName());
 
-  private final java.security.SecureRandom instance;
+  private final SecureRandom instance;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.random.JavaCryptoRandom}.
+   * Constructs a {@link JavaCryptoRandom}.
    *
    * @param properties the configuration properties.
    * @throws NoSuchAlgorithmException if no Provider supports a SecureRandomSpi implementation for
    *         the specified algorithm.
    */
   public JavaCryptoRandom(Properties properties) throws NoSuchAlgorithmException {
-    instance = java.security.SecureRandom.getInstance(properties
+    instance = SecureRandom.getInstance(properties
       .getProperty(ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_KEY,
         ConfigurationKeys.COMMONS_CRYPTO_SECURE_RANDOM_JAVA_ALGORITHM_DEFAULT));
   }
@@ -57,7 +58,7 @@ public class JavaCryptoRandom implements CryptoRandom {
   }
 
   /**
-   * Overrides {@link org.apache.commons.crypto.random.CryptoRandom#nextBytes(byte[])}.
+   * Overrides {@link CryptoRandom#nextBytes(byte[])}.
    * Generates random bytes and places them into a user-supplied byte array.
    * The number of random bytes produced is equal to the length of the byte array.
    *

--- a/src/main/java/org/apache/commons/crypto/random/OpensslCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/OpensslCryptoRandom.java
@@ -34,7 +34,7 @@ import org.apache.commons.crypto.utils.Utils;
  *
  * If using an Intel chipset with RDRAND, the high-performance hardware
  * random number generator will be used and it's much faster than
- * {@link java.security.SecureRandom}. If RDRAND is unavailable, default
+ * {@link SecureRandom}. If RDRAND is unavailable, default
  * OpenSSL secure random generator will be used. It's still faster
  * and can generate strong random bytes.
  * <p/>
@@ -73,7 +73,7 @@ public class OpensslCryptoRandom extends Random implements CryptoRandom {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.random.OpensslCryptoRandom}.
+   * Constructs a {@link OpensslCryptoRandom}.
    *
    * @param props the configuration properties.
    * @throws NoSuchAlgorithmException if no Provider supports a SecureRandomSpi implementation for

--- a/src/main/java/org/apache/commons/crypto/random/OsCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/OsCryptoRandom.java
@@ -59,7 +59,7 @@ public class OsCryptoRandom extends Random implements CryptoRandom {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.random.OsCryptoRandom}.
+   * Constructs a {@link OsCryptoRandom}.
    *
    * @param props the configuration properties.
    */
@@ -83,7 +83,7 @@ public class OsCryptoRandom extends Random implements CryptoRandom {
   }
 
   /**
-   * Overrides {@link org.apache.commons.crypto.random.CryptoRandom#nextBytes(byte[])}.
+   * Overrides {@link CryptoRandom#nextBytes(byte[])}.
    * Generates random bytes and places them into a user-supplied byte array.
    * The number of random bytes produced is equal to the length of the byte array.
    *

--- a/src/main/java/org/apache/commons/crypto/stream/CTRCryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CTRCryptoInputStream.java
@@ -79,7 +79,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   private boolean cipherReset = false;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
+   * Constructs a {@link CTRCryptoInputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -95,7 +95,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
+   * Constructs a {@link CTRCryptoInputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -111,7 +111,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
+   * Constructs a {@link CTRCryptoInputStream}.
    *
    * @param in the input stream.
    * @param cipher the CryptoCipher instance.
@@ -126,7 +126,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
+   * Constructs a {@link CTRCryptoInputStream}.
    *
    * @param in the ReadableByteChannel instance.
    * @param cipher the cipher instance.
@@ -141,7 +141,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
+   * Constructs a {@link CTRCryptoInputStream}.
    *
    * @param input the input data.
    * @param cipher the CryptoCipher instance.
@@ -160,7 +160,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
+   * Constructs a {@link CTRCryptoInputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -178,7 +178,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   *Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
+   *Constructs a {@link CTRCryptoInputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -196,7 +196,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
+   * Constructs a {@link CTRCryptoInputStream}.
    *
    * @param in the InputStream instance.
    * @param cipher the CryptoCipher instance.
@@ -212,7 +212,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
+   * Constructs a {@link CTRCryptoInputStream}.
    *
    * @param in the ReadableByteChannel instance.
    * @param cipher the CryptoCipher instance.
@@ -228,7 +228,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoInputStream}.
+   * Constructs a {@link CTRCryptoInputStream}.
    *
    * @param input the input data.
    * @param cipher the CryptoCipher instance.
@@ -256,7 +256,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   * Overrides the {@link org.apache.commons.crypto.stream.CryptoInputStream#skip(long)}.
+   * Overrides the {@link CryptoInputStream#skip(long)}.
    * Skips over and discards <code>n</code> bytes of data from this input
    * stream.
    *
@@ -295,7 +295,7 @@ public class CTRCryptoInputStream extends CryptoInputStream {
   }
 
   /**
-   * Overrides the {@link org.apache.commons.crypto.stream.CTRCryptoInputStream#read(ByteBuffer)}.
+   * Overrides the {@link CTRCryptoInputStream#read(ByteBuffer)}.
    * Reads a sequence of bytes from this channel into the given buffer.
    *
    * @param buf The buffer into which bytes are to be transferred.

--- a/src/main/java/org/apache/commons/crypto/stream/CTRCryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CTRCryptoOutputStream.java
@@ -78,7 +78,7 @@ public class CTRCryptoOutputStream extends CryptoOutputStream {
   private boolean cipherReset = false;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
+   * Constructs a {@link CTRCryptoOutputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -94,7 +94,7 @@ public class CTRCryptoOutputStream extends CryptoOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
+   * Constructs a {@link CTRCryptoOutputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -110,7 +110,7 @@ public class CTRCryptoOutputStream extends CryptoOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
+   * Constructs a {@link CTRCryptoOutputStream}.
    *
    * @param out the output stream.
    * @param cipher the CryptoCipher instance.
@@ -125,7 +125,7 @@ public class CTRCryptoOutputStream extends CryptoOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
+   * Constructs a {@link CTRCryptoOutputStream}.
    *
    * @param channel the WritableByteChannel instance.
    * @param cipher the CryptoCipher instance.
@@ -140,7 +140,7 @@ public class CTRCryptoOutputStream extends CryptoOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
+   * Constructs a {@link CTRCryptoOutputStream}.
    *
    * @param output the Output instance.
    * @param cipher the CryptoCipher instance.
@@ -156,7 +156,7 @@ public class CTRCryptoOutputStream extends CryptoOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
+   * Constructs a {@link CTRCryptoOutputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -174,7 +174,7 @@ public class CTRCryptoOutputStream extends CryptoOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
+   * Constructs a {@link CTRCryptoOutputStream}.
    *
    * @param props The <code>Properties</code> class represents a set of
    *              properties.
@@ -192,7 +192,7 @@ public class CTRCryptoOutputStream extends CryptoOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
+   * Constructs a {@link CTRCryptoOutputStream}.
    *
    * @param out the output stream.
    * @param cipher the CryptoCipher instance.
@@ -209,7 +209,7 @@ public class CTRCryptoOutputStream extends CryptoOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
+   * Constructs a {@link CTRCryptoOutputStream}.
    *
    * @param channel the WritableByteChannel instance.
    * @param cipher the CryptoCipher instance.
@@ -227,7 +227,7 @@ public class CTRCryptoOutputStream extends CryptoOutputStream {
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CTRCryptoOutputStream}.
+   * Constructs a {@link CTRCryptoOutputStream}.
    *
    * @param output the output stream.
    * @param cipher the CryptoCipher instance.

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
@@ -82,7 +82,7 @@ public class CryptoOutputStream extends OutputStream implements
   ByteBuffer outBuffer;
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CryptoOutputStream}.
+   * Constructs a {@link CryptoOutputStream}.
    *
    * @param transformation the CipherTransformation instance.
    * @param props The <code>Properties</code> class represents a set of
@@ -105,7 +105,7 @@ public class CryptoOutputStream extends OutputStream implements
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CryptoOutputStream}.
+   * Constructs a {@link CryptoOutputStream}.
    *
    * @param transformation the CipherTransformation instance.
    * @param props The <code>Properties</code> class represents a set of
@@ -127,7 +127,7 @@ public class CryptoOutputStream extends OutputStream implements
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CryptoOutputStream}.
+   * Constructs a {@link CryptoOutputStream}.
    *
    * @param out the output stream.
    * @param cipher the CryptoCipher instance.
@@ -142,7 +142,7 @@ public class CryptoOutputStream extends OutputStream implements
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CryptoOutputStream}.
+   * Constructs a {@link CryptoOutputStream}.
    *
    * @param channel the WritableByteChannel instance.
    * @param cipher the cipher instance.
@@ -157,7 +157,7 @@ public class CryptoOutputStream extends OutputStream implements
   }
 
   /**
-   * Constructs a {@link org.apache.commons.crypto.stream.CryptoOutputStream}.
+   * Constructs a {@link CryptoOutputStream}.
    *
    * @param output the output stream.
    * @param cipher the CryptoCipher instance.

--- a/src/main/java/org/apache/commons/crypto/utils/Utils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/Utils.java
@@ -235,7 +235,7 @@ public class Utils {
   /**
    * This method is only for Counter (CTR) mode. Generally the CryptoCipher calculates the
    * IV and maintain encryption context internally.For example a
-   * {@link javax.crypto.Cipher} will maintain its encryption context internally
+   * {@link Cipher} will maintain its encryption context internally
    * when we do encryption/decryption using the CryptoCipher#update interface.
    * <p/>
    * Encryption/Decryption is not always on the entire file. For example,


### PR DESCRIPTION
[CRYPTO-40](https://issues.apache.org/jira/browse/CRYPTO-40)

Since we have resolved the class name conflicts, the full qualified name for shadowing class such as Cipher and SecureRandom is longer needed.