### PR TITLE
CRYPTO-45: Document how to build Commons Crypto

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -4,12 +4,12 @@ Build instructions for Apache Commons Crypto
 Requirements:
 
 * Unix System
-* JDK 1.6+ (environment variable JAVA_HOME must be set)
+* JDK 1.6 or above (environment variable JAVA_HOME must be set)
 * Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy
   Files (if running unit tests)
-* Maven 3.0 or later
+* Maven 3.0 or above
 * Make
-* Openssl devel 1.0.1c+
+* Openssl devel 1.0.1c or above 
 
 ----------------------------------------------------------------------------------
 Install JCE Unlimited Strength Jurisdiction Policy Files:
@@ -31,7 +31,7 @@ Check Openssl version:
 
   $ openssl version
 
-If it is not 1.0.1c+, upgrade Openssl version to 1.0.1c+:
+If it is not 1.0.1c or above, upgrade Openssl version to 1.0.1c or above:
 
   $ brew install homebrew/versions/openssl101
   $ brew link openssl --force

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -25,19 +25,19 @@ Install JCE Unlimited Strength Jurisdiction Policy Files to JDK:
 Copy downloaded local_policy.jar and US_export_policy.jar to <java-home>/jre/lib/security/
 
 ----------------------------------------------------------------------------------
-Upgrade OpenSSL:
-
-Upgrade OpenSSL in Linux:
-
-You can follow your OS distribution instructions to upgrade OpenSSL to a proper version.
-
-Upgrade OpenSSL in Mac:
+Verify OpenSSL version:
 
 Check OpenSSL version:
 
   $ openssl version
 
 If it is not 1.0.1c or above, upgrade OpenSSL version to 1.0.1c or above:
+
+Upgrade OpenSSL in Linux:
+
+You can follow your OS distribution instructions to upgrade OpenSSL to a proper version.
+
+Upgrade OpenSSL in Mac:
 
   $ brew install homebrew/versions/openssl101
   $ brew link openssl --force

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -1,0 +1,74 @@
+Build instructions for Apache Commons Crypto
+
+----------------------------------------------------------------------------------
+Requirements:
+
+* Unix System
+* JDK 1.6+ (environment variable JAVA_HOME must be set)
+* Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy
+  Files (if running unit tests)
+* Maven 3.0 or later
+* Make
+* Openssl devel 1.0.1c+
+
+----------------------------------------------------------------------------------
+Install JCE Unlimited Strength Jurisdiction Policy Files:
+
+Download the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files from Oracle:
+
+For JDK 1.6: http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html
+For JDK 1.7: http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html
+For JDK 1.8: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html
+
+Install JCE Unlimited Strength Jurisdiction Policy Files to JDK:
+
+Copy downloaded local_policy.jar and US_export_policy.jar to <java-home>/jre/lib/security/
+
+----------------------------------------------------------------------------------
+Upgrade Openssl version in Mac:
+
+Check Openssl version:
+
+  $ openssl version
+
+If it is not 1.0.1c+, upgrade Openssl version to 1.0.1c+:
+
+  $ brew install homebrew/versions/openssl101
+  $ brew link openssl --force
+
+----------------------------------------------------------------------------------
+Maven build goals:
+
+* Clean                     : mvn clean
+* Compile                   : mvn compile
+* Run tests                 : mvn test
+* Create JAR                : mvn package
+* Run findbugs              : mvn compile -Pfindbugs
+* Run checkstyle            : mvn compile checkstyle:checkstyle
+* Install JAR in M2 cache   : mvn install
+* Deploy JAR to Maven repo  : mvn deploy
+* Run Rat                   : mvn apache-rat:check
+* Build javadocs            : mvn javadoc:javadoc
+* Change version            : mvn versions:set -DnewVersion=NEWVERSION
+
+----------------------------------------------------------------------------------
+Importing projects to eclipse
+
+Generate eclipse project files.
+
+  $ mvn eclipse:eclipse -DskipTests
+
+At last, import to eclipse by specifying the root directory of the project via
+[File] > [Import] > [Existing Projects into Workspace].
+
+----------------------------------------------------------------------------------
+Building distributions:
+
+Create binary distribution:
+
+  $ mvn package -DskipTests
+
+Create a local staging version of the website (in /tmp/crypto-site):
+
+  $ mvn clean site; mvn site:stage -DstagingDirectory=/tmp/crypto-site
+

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -3,13 +3,13 @@ Build instructions for Apache Commons Crypto
 ----------------------------------------------------------------------------------
 Requirements:
 
-* Unix System
+* Unix System (Linux or Mac)
 * JDK 1.6 or above (environment variable JAVA_HOME must be set)
 * Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy
   Files (if running unit tests)
 * Maven 3.0 or above
 * Make
-* Openssl devel 1.0.1c or above 
+* OpenSSL devel 1.0.1c or above
 
 ----------------------------------------------------------------------------------
 Install JCE Unlimited Strength Jurisdiction Policy Files:
@@ -25,13 +25,19 @@ Install JCE Unlimited Strength Jurisdiction Policy Files to JDK:
 Copy downloaded local_policy.jar and US_export_policy.jar to <java-home>/jre/lib/security/
 
 ----------------------------------------------------------------------------------
-Upgrade Openssl version in Mac:
+Upgrade OpenSSL:
 
-Check Openssl version:
+Upgrade OpenSSL in Linux:
+
+You can follow your OS distribution instructions to upgrade OpenSSL to a proper version.
+
+Upgrade OpenSSL in Mac:
+
+Check OpenSSL version:
 
   $ openssl version
 
-If it is not 1.0.1c or above, upgrade Openssl version to 1.0.1c or above:
+If it is not 1.0.1c or above, upgrade OpenSSL version to 1.0.1c or above:
 
   $ brew install homebrew/versions/openssl101
   $ brew link openssl --force

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,15 @@ Features
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <version>${commons.rat.version}</version>
+        <configuration>
+          <excludes>
+          <exclude>.gitattributes</exclude>
+          <exclude>.gitignore</exclude>
+          <exclude>.git/**</exclude>
+          <exclude>.idea/**</exclude>
+          <exclude>**/build/**</exclude>
+          </excludes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -337,11 +337,11 @@ Features
         <version>${commons.rat.version}</version>
         <configuration>
           <excludes>
-          <exclude>.gitattributes</exclude>
-          <exclude>.gitignore</exclude>
-          <exclude>.git/**</exclude>
-          <exclude>.idea/**</exclude>
-          <exclude>**/build/**</exclude>
+            <exclude>.gitattributes</exclude>
+            <exclude>.gitignore</exclude>
+            <exclude>.git/**</exclude>
+            <exclude>.idea/**</exclude>
+            <exclude>**/build/**</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
This PR adds the Developer Guide. For User Guide, it's already available in src/site/xdoc/userguide.xml.