### PR TITLE
CRYPTO-56: add informative error message, keep consistent with JDK

### DIFF
--- a/src/main/native/org/apache/commons/crypto/cipher/OpensslNative.c
+++ b/src/main/native/org/apache/commons/crypto/cipher/OpensslNative.c
@@ -248,11 +248,13 @@ JNIEXPORT jlong JNICALL Java_org_apache_commons_crypto_cipher_OpensslNative_init
   int jIvLen = (*env)->GetArrayLength(env, iv);
   if (jKeyLen != KEY_LENGTH_128 && jKeyLen != KEY_LENGTH_192
         && jKeyLen != KEY_LENGTH_256) {
-    THROW(env, "java/security/InvalidKeyException", "Invalid key length.");
+    char str[64] = {0};
+    snprintf(str, sizeof(str), "Invalid AES key length: %d bytes", jKeyLen);
+    THROW(env, "java/security/InvalidKeyException", str);
     return (jlong)0;
   }
   if (jIvLen != IV_LENGTH) {
-    THROW(env, "java/security/InvalidAlgorithmParameterException", "Wrong IV length.");
+    THROW(env, "java/security/InvalidAlgorithmParameterException", "Wrong IV length: must be 16 bytes long");
     return (jlong)0;
   }
 

--- a/src/test/java/org/apache/commons/crypto/cipher/OpensslCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/OpensslCipherTest.java
@@ -149,7 +149,7 @@ public class OpensslCipherTest extends AbstractCipherTest {
             cipher.init(Openssl.ENCRYPT_MODE, invalidKey, IV);
             Assert.fail("java.security.InvalidKeyException should be thrown.");
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Invalid key length."));
+            Assert.assertTrue(e.getMessage().contains("Invalid AES key length: " + invalidKey.length + " bytes"));
             throw e;
         }
     }
@@ -167,7 +167,7 @@ public class OpensslCipherTest extends AbstractCipherTest {
             cipher.init(Openssl.ENCRYPT_MODE, KEY, invalidIV);
             Assert.fail("java.security.InvalidAlgorithmParameterException should be thrown.");
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Wrong IV length."));
+            Assert.assertTrue(e.getMessage().contains("Wrong IV length: must be 16 bytes long"));
             throw e;
         }
     }


### PR DESCRIPTION
[CRYPTO-56](https://issues.apache.org/jira/browse/CRYPTO-56) 
JDK's error message is more informative. it would be better to keep consistent with JDK
