### PR TITLE
CRYPTO-58: Generate VERSION file using maven resource filtering.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -18,7 +18,7 @@
 TARGET:=target
 SRC:=src/main/java
 SRC_NATIVE:=src/main/native
-include $(SRC)/org/apache/commons/crypto/VERSION
+include $(TARGET)/classes/org/apache/commons/crypto/VERSION
 
 ifndef JAVA_HOME
 $(error Set JAVA_HOME environment variable)

--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,12 @@ Features
   </licenses>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources/</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -314,6 +320,20 @@ Features
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.7</version>
+        <executions>
+          <execution>
+            <id>create-version-file</id>
+            <!-- change phase of maven-resource-plugin -->
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>

--- a/src/main/resources/org/apache/commons/crypto/VERSION
+++ b/src/main/resources/org/apache/commons/crypto/VERSION
@@ -14,4 +14,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-VERSION=1.0.0-SNAPSHOT
+VERSION=${project.version}


### PR DESCRIPTION
Generating this file using maven resource filtering is less error prone.
Currenlty crypto uses a mix of sources for determining the version
number:
- NativeClassLoader first reads from META-INF and then from VERSION
- Makefile.common only uses the VERSION file

This change makes sure the version number will be set from only one
source, which is maven.