### PR TITLE
CRYPTO-66: Fix compiling warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,19 +33,11 @@ NATIVE_DLL:=$(NATIVE_TARGET_DIR)/$(LIBNAME)
 
 all: $(NATIVE_DLL)
 
-$(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpensslNative.class : $(SRC)/org/apache/commons/crypto/cipher/OpensslNative.java
-	@mkdir -p $(TARGET)/jni-classes
-	$(JAVAC) -source 1.6 -target 1.6 -d $(TARGET)/jni-classes -sourcepath $(SRC) $<
+$(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpensslNative.h: $(TARGET)/classes/org/apache/commons/crypto/cipher/OpensslNative.class
+	$(JAVAH) -force -classpath $(TARGET)/jni-classes:$(TARGET)/classes -o $@ org.apache.commons.crypto.cipher.OpensslNative
 
-$(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslCryptoRandomNative.class : $(SRC)/org/apache/commons/crypto/random/OpensslCryptoRandomNative.java
-	@mkdir -p $(TARGET)/jni-classes
-	$(JAVAC) -source 1.6 -target 1.6 -d $(TARGET)/jni-classes -sourcepath $(SRC) $<
-
-$(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpensslNative.h: $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpensslNative.class
-	$(JAVAH) -force -classpath $(TARGET)/jni-classes -o $@ org.apache.commons.crypto.cipher.OpensslNative
-
-$(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslCryptoRandomNative.h: $(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslCryptoRandomNative.class
-	$(JAVAH) -force -classpath $(TARGET)/jni-classes -o $@ org.apache.commons.crypto.random.OpensslCryptoRandomNative
+$(TARGET)/jni-classes/org/apache/commons/crypto/random/OpensslCryptoRandomNative.h: $(TARGET)/classes/org/apache/commons/crypto/random/OpensslCryptoRandomNative.class
+	$(JAVAH) -force -classpath $(TARGET)/jni-classes:$(TARGET)/classes -o $@ org.apache.commons.crypto.random.OpensslCryptoRandomNative
 
 $(COMMONS_CRYPTO_OUT)/OpensslNative.o : $(SRC_NATIVE)/org/apache/commons/crypto/cipher/OpensslNative.c $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpensslNative.h
 	@mkdir -p $(@D)

--- a/Makefile.common
+++ b/Makefile.common
@@ -33,12 +33,7 @@ JAVAC := "$$JAVA_HOME/bin/javac"
 JAVAH := "$$JAVA_HOME/bin/javah"
 
 OSINFO_CLASS := org.apache.commons.crypto.utils.OSInfo
-OSINFO_PROG := lib/org/apache/commons/crypto/utils/OSInfo.class
-
-## building OSInfo.java
-$(info compiling OSInfo.java)
-$(shell mkdir -p lib)
-$(shell $(JAVAC) src/main/java/org/apache/commons/crypto/utils/OSInfo.java -d lib)
+OSINFO_PROG := $(TARGET)/classes/org/apache/commons/crypto/utils/OSInfo.class
 
 OS_NAME := $(shell $(JAVA) -cp lib $(OSINFO_CLASS) --os)
 OS_ARCH := $(shell $(JAVA) -cp lib $(OSINFO_CLASS) --arch)

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@ The following provides more details on the included cryptographic software:
         <executions>
           <execution>
             <id>make</id>
-            <phase>generate-sources</phase>
+            <phase>process-classes</phase>
             <goals>
               <goal>run</goal>
             </goals>


### PR DESCRIPTION
Fixing: https://issues.apache.org/jira/browse/CRYPTO-66