### PR TITLE
CRYPTO-76: Remove log dependence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -487,11 +487,13 @@ The following provides more details on the included cryptographic software:
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>${commons-logging.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j-api.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/apache/commons/crypto/cipher/Openssl.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/Openssl.java
@@ -20,14 +20,10 @@ package org.apache.commons.crypto.cipher;
 import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.util.StringTokenizer;
-
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.ShortBufferException;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.apache.commons.crypto.utils.NativeCodeLoader;
 import org.apache.commons.crypto.utils.Utils;
@@ -37,7 +33,6 @@ import org.apache.commons.crypto.utils.Utils;
  * It's flexible to add other crypto algorithms/modes.
  */
 final class Openssl {
-    private static final Log LOG = LogFactory.getLog(Openssl.class.getName());
 
     // Mode constant defined by Openssl JNI
     public static final int ENCRYPT_MODE = 1;
@@ -101,7 +96,6 @@ final class Openssl {
             }
         } catch (Throwable t) {
             loadingFailure = t.getMessage();
-            LOG.debug("Failed to load OpenSSL CryptoCipher.", t);
         } finally {
             loadingFailureReason = loadingFailure;
         }

--- a/src/main/java/org/apache/commons/crypto/conf/ConfigurationKeys.java
+++ b/src/main/java/org/apache/commons/crypto/conf/ConfigurationKeys.java
@@ -130,9 +130,22 @@ public class ConfigurationKeys {
     public static final String COMMONS_CRYPTO_LIB_TEMPDIR_KEY = CONF_PREFIX
             + "lib.tempdir";
 
-  /**
-   * The private constructor of {@Link ConfigurationKeys}.
-   */
+    /**
+     * The configuration key of enable fallback on native failed.
+     */
+    public static final String
+            COMMONS_CRYPTO_ENABLE_FALLBACK_ON_NATIVE_FAILED_KEY = CONF_PREFIX +
+            "enable.fallback";
+
+    /**
+     * The default value of enable fallback on native failed.
+     */
+    public static final boolean
+            COMMONS_CRYPTO_ENABLE_FALLBACK_ON_NATIVE_FAILED_DEFAULT = true;
+
+    /**
+     * The private constructor of {@Link ConfigurationKeys}.
+     */
     private ConfigurationKeys() {
     }
 }

--- a/src/main/java/org/apache/commons/crypto/random/OpensslCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/OpensslCryptoRandom.java
@@ -21,9 +21,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Properties;
 import java.util.Random;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import org.apache.commons.crypto.utils.NativeCodeLoader;
 import org.apache.commons.crypto.utils.Utils;
 
@@ -46,8 +43,6 @@ import org.apache.commons.crypto.utils.Utils;
  */
 public class OpensslCryptoRandom extends Random implements CryptoRandom {
     private static final long serialVersionUID = -7828193502768789584L;
-    private static final Log LOG = LogFactory.getLog(OpensslCryptoRandom.class
-            .getName());
 
     /** If native SecureRandom unavailable, use java SecureRandom */
     private final JavaCryptoRandom fallback;
@@ -60,7 +55,7 @@ public class OpensslCryptoRandom extends Random implements CryptoRandom {
                 OpensslCryptoRandomNative.initSR();
                 opensslLoaded = true;
             } catch (Throwable t) {
-                LOG.error("Failed to load Openssl CryptoRandom", t);
+                ; // NOPMD
             }
         }
         nativeEnabled = opensslLoaded;

--- a/src/main/java/org/apache/commons/crypto/random/OsCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/OsCryptoRandom.java
@@ -25,19 +25,16 @@ import java.util.Random;
 
 import org.apache.commons.crypto.utils.IOUtils;
 import org.apache.commons.crypto.utils.Utils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 /**
  * A Random implementation that uses random bytes sourced from the operating
  * system.
  */
 public class OsCryptoRandom extends Random implements CryptoRandom {
-    public static final Log LOG = LogFactory.getLog(OsCryptoRandom.class);
 
     private static final long serialVersionUID = 6391500337172057900L;
 
-    private final int RESERVOIR_LENGTH = 8192;
+    private static final int RESERVOIR_LENGTH = 8192;
 
     private String randomDevPath;
 
@@ -131,7 +128,7 @@ public class OsCryptoRandom extends Random implements CryptoRandom {
     @Override
     synchronized public void close() {
         if (stream != null) {
-            IOUtils.cleanup(LOG, stream);
+            IOUtils.cleanup(stream);
             stream = null;
         }
     }

--- a/src/main/java/org/apache/commons/crypto/utils/IOUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/IOUtils.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.crypto.stream.input.Input;
-import org.apache.commons.logging.Log;
 
 /**
  * General utility methods for working with IO.
@@ -85,18 +84,15 @@ public final class IOUtils {
      * Closes the Closeable objects and <b>ignore</b> any {@link IOException} or
      * null pointers. Must only be used for cleanup in exception handlers.
      *
-     * @param log the log to record problems to at debug level. Can be null.
      * @param closeables the objects to close.
      */
-    public static void cleanup(Log log, java.io.Closeable... closeables) {
+    public static void cleanup(java.io.Closeable... closeables) {
         for (java.io.Closeable c : closeables) {
             if (c != null) {
                 try {
                     c.close();
                 } catch (Throwable e) {
-                    if (log != null && log.isDebugEnabled()) {
-                        log.debug("Exception in closing " + c, e);
-                    }
+                    ; // NOPMD
                 }
             }
         }

--- a/src/main/java/org/apache/commons/crypto/utils/NativeCodeLoader.java
+++ b/src/main/java/org/apache/commons/crypto/utils/NativeCodeLoader.java
@@ -27,17 +27,12 @@ import java.net.URL;
 import java.util.Properties;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 /**
  * A helper to load the native code i.e. libcommons-crypto.so. This handles the
  * fallback to either the bundled libcommons-crypto-Linux-i386-32.so or the
  * default java implementations where appropriate.
  */
 public final class NativeCodeLoader {
-
-    private static final Log LOG = LogFactory.getLog(NativeCodeLoader.class);
 
     private final static boolean nativeCodeLoaded;
     /**
@@ -48,11 +43,9 @@ public final class NativeCodeLoader {
 
     static {
         // Try to load native library and set fallback flag appropriately
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Trying to load the custom-built native-commons-crypto library...");
-        }
-
         boolean nativeLoaded = false;
+
+        //Trying to load the custom-built native-commons-crypto library...");
         try {
             File nativeLibFile = findNativeLibrary();
             if (nativeLibFile != null) {
@@ -62,22 +55,13 @@ public final class NativeCodeLoader {
                 // Load preinstalled library (in the path -Djava.library.path)
                 System.loadLibrary("commons-crypto");
             }
-            LOG.debug("Loaded the native library");
+            // Loaded the native library
             nativeLoaded = true;
         } catch (Throwable t) {
-            // Ignore failure to load
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Failed to load native library with error: " + t);
-                LOG.debug("java.library.path="
-                        + System.getProperty("java.library.path"));
-            }
+            ;// NOPMD: Ignore failure to load
         }
 
         nativeCodeLoaded = nativeLoaded;
-        if (!nativeCodeLoaded) {
-            LOG.warn("Unable to load native library for the platform... "
-                    + "using builtin-java classes where applicable");
-        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/utils/Utils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/Utils.java
@@ -275,7 +275,7 @@ public final class Utils {
         int sum = 0;
         while (i-- > 0) {
             // (sum >>> Byte.SIZE) is the carry for addition
-            sum = (initIV[i] & 0xff) + (sum >>> Byte.SIZE);
+            sum = (initIV[i] & 0xff) + (sum >>> Byte.SIZE); // NOPMD
             if (j++ < 8) { // Big-endian, and long is 8 bytes length
                 sum += (byte) counter & 0xff;
                 counter >>>= 8;
@@ -384,5 +384,26 @@ public final class Utils {
             }
         }
         return res;
+    }
+
+    /**
+     * Returns true if Fallback is enabled when native failed.
+     * @param props The <code>Properties</code> class represents a set of
+     *        properties.
+     * @return true if Fallback is enabled when native failed.
+     */
+    public static boolean isFallbackEnable(Properties props) {
+        String enableFallback = props.getProperty(ConfigurationKeys.
+                COMMONS_CRYPTO_ENABLE_FALLBACK_ON_NATIVE_FAILED_KEY);
+        if (enableFallback == null || enableFallback.isEmpty()) {
+            enableFallback = System.getProperty(ConfigurationKeys.
+                    COMMONS_CRYPTO_ENABLE_FALLBACK_ON_NATIVE_FAILED_KEY);
+        }
+        if (enableFallback == null || enableFallback.isEmpty()) {
+            return ConfigurationKeys
+                    .COMMONS_CRYPTO_ENABLE_FALLBACK_ON_NATIVE_FAILED_DEFAULT;
+        } else {
+            return Boolean.valueOf(enableFallback);
+        }
     }
 }

--- a/src/test/java/org/apache/commons/crypto/cipher/CryptoCipherFactoryTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/CryptoCipherFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.crypto.conf.ConfigurationKeys;
 
 import org.junit.Assert;
 import org.junit.Test;
+import static junit.framework.Assert.fail;
 
 public class CryptoCipherFactoryTest {
     @Test
@@ -37,7 +38,8 @@ public class CryptoCipherFactoryTest {
     @Test
     public void testEmptyCipher() throws GeneralSecurityException {
         Properties properties = new Properties();
-        properties.put(ConfigurationKeys.COMMONS_CRYPTO_CIPHER_CLASSES_KEY, "");
+        properties.setProperty(
+                ConfigurationKeys.COMMONS_CRYPTO_CIPHER_CLASSES_KEY, "");
         CryptoCipher defaultCipher = CryptoCipherFactory.getInstance(
                 CipherTransformation.AES_CBC_NOPADDING, properties);
         Assert.assertEquals(OpensslCipher.class.getName(), defaultCipher
@@ -47,11 +49,28 @@ public class CryptoCipherFactoryTest {
     @Test
     public void testInvalidCipher() throws GeneralSecurityException {
         Properties properties = new Properties();
-        properties.put(ConfigurationKeys.COMMONS_CRYPTO_CIPHER_CLASSES_KEY,
+        properties.setProperty(ConfigurationKeys.COMMONS_CRYPTO_CIPHER_CLASSES_KEY,
                 "InvalidCipherName");
         CryptoCipher defaultCipher = CryptoCipherFactory.getInstance(
                 CipherTransformation.AES_CBC_NOPADDING, properties);
         Assert.assertEquals(JceCipher.class.getName(), defaultCipher.getClass()
                 .getName());
+    }
+
+    @Test
+    public void testDisableFallback() throws GeneralSecurityException {
+        Properties properties = new Properties();
+        properties.setProperty(
+                ConfigurationKeys.COMMONS_CRYPTO_CIPHER_CLASSES_KEY,
+                "InvalidCipherName");
+        properties.setProperty(ConfigurationKeys
+            .COMMONS_CRYPTO_ENABLE_FALLBACK_ON_NATIVE_FAILED_KEY, "false");
+        try {
+            CryptoCipher defaultCipher = CryptoCipherFactory.getInstance(
+                    CipherTransformation.AES_CBC_NOPADDING, properties);
+            fail("Should throw an exception when DisableFallback");
+        } catch (Exception e) {
+            ;
+        }
     }
 }


### PR DESCRIPTION
Fixing: https://issues.apache.org/jira/browse/CRYPTO-76

About the logging of native library failure, users of CRYPTO could get the information about whether native is enabled or native failure reason from org.apache.commons.crypto.utils.NativeCodeLoader#isNativeCodeLoaded() or org.apache.commons.crypto.cipher.Openssl#loadingFailureReason(), they could log these information in their system if they need.
At the same time, I think we can add an option for "native only" (Currently, when loading native failed, we log native failure error and use JCE implementation as fallback directly), the property in configuration may like "ENABLE_FALLBACK_ON_NATIVE_FAILED", if user disable the option, it could throw an exception when loading native failed.