### PR TITLE
CRYPTO-98:Makefile does not use MVN or TAR variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,8 @@
 #
 include Makefile.common
 
-MVN:=mvn
-
 COMMONS_CRYPTO_OUT:=$(TARGET)/$(commons-crypto)-$(os_arch)
 COMMONS_CRYPTO_OBJ:=$(addprefix $(COMMONS_CRYPTO_OUT)/,OpensslCryptoRandom.o OpenSslNative.o)
-
-ifeq ($(OS_NAME),SunOS)
-  TAR:= gtar
-else
-  TAR:= tar
-endif
 
 # Windows uses different path separators
 ifeq ($(OS_NAME),Windows)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CRYPTO-98