### PR TITLE
CRYPTO-103: NativeCodeLoader.getVersion() seems badly named

### DIFF
--- a/src/main/java/org/apache/commons/crypto/Crypto.java
+++ b/src/main/java/org/apache/commons/crypto/Crypto.java
@@ -46,15 +46,6 @@ public final class Crypto {
             + "lib.tempdir";
 
     /**
-     * Gets the currently active version of Apache Commons Crypto.
-     * 
-     * @return the version
-     */
-    public static String getVersion() {
-        return NativeCodeLoader.getVersion();
-    }
-
-    /**
      * Checks whether the native code has been successfully loaded for the platform.
      * 
      * @return true if the native code has been loaded successfully.

--- a/src/main/java/org/apache/commons/crypto/NativeCodeLoader.java
+++ b/src/main/java/org/apache/commons/crypto/NativeCodeLoader.java
@@ -150,7 +150,7 @@ final class NativeCodeLoader {
         // can read the libcommons-crypto multiple times.
         String uuid = UUID.randomUUID().toString();
         String extractedLibFileName = String.format("commons-crypto-%s-%s-%s",
-                getVersion(), uuid, libraryFileName);
+                getCryptoVersion(), uuid, libraryFileName);
         File extractedLibFile = new File(targetFolder, extractedLibFileName);
 
         InputStream reader = null;
@@ -220,7 +220,7 @@ final class NativeCodeLoader {
      *
      * @return the version string
      */
-    static String getVersion() {
+    static String getCryptoVersion() {
         URL versionFile = NativeCodeLoader.class
                 .getResource("/META-INF/maven/org.apache.commons.crypto/commons-crypto/pom.properties");
         String version = "unknown";

--- a/src/test/java/org/apache/commons/crypto/NativeCodeLoaderTest.java
+++ b/src/test/java/org/apache/commons/crypto/NativeCodeLoaderTest.java
@@ -39,12 +39,12 @@ public class NativeCodeLoaderTest {
             System.out.println("** WARN: Native (JNI) code was not loaded: " 
                 + NativeCodeLoader.getLoadingError());
         }
-        assertNotNull(NativeCodeLoader.getVersion());
+        assertNotNull(NativeCodeLoader.getCryptoVersion());
     }
 
     @Test
     public void testGetVersion() {
-        assertNotNull(NativeCodeLoader.getVersion());
+        assertNotNull(NativeCodeLoader.getCryptoVersion());
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CRYPTO-103