### PR TITLE
[CRYPTO-125] CryptoOutputStream does not call write in a loop when underlying channel works in non-block mode

### DIFF
--- a/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
@@ -388,7 +388,9 @@ public class CryptoOutputStream extends OutputStream implements
         outBuffer.flip();
 
         // write to output
-        output.write(outBuffer);
+        while (outBuffer.hasRemaining()) {
+            output.write(outBuffer);
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
@@ -360,7 +360,9 @@ public class CryptoOutputStream extends OutputStream implements
         outBuffer.flip();
 
         // write to output
-        output.write(outBuffer);
+        while (outBuffer.hasRemaining()) {
+            output.write(outBuffer);
+        }
     }
 
     /**


### PR DESCRIPTION
Add a loop to drain out the internal buffer.