### PR TITLE
adding support for openssl 1.1.0g in common crypto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,15 +48,15 @@ $(TARGET)/jni-classes/org/apache/commons/crypto/OpenSslInfoNative.h: $(TARGET)/c
 
 $(COMMONS_CRYPTO_OUT)/OpenSslNative.o : $(SRC_NATIVE)/org/apache/commons/crypto/cipher/OpenSslNative.c $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpenSslNative.h
 	@mkdir -p $(@D)
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -DOPENSSL_API_COMPAT=$(OPENSSL_VERSION) -c $< -o $@
 
 $(COMMONS_CRYPTO_OUT)/OpenSslCryptoRandomNative.o : $(SRC_NATIVE)/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.c $(TARGET)/jni-classes/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.h
 	@mkdir -p $(@D)
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -DOPENSSL_API_COMPAT=$(OPENSSL_VERSION) -c $< -o $@
 
 $(COMMONS_CRYPTO_OUT)/OpenSslInfoNative.o : $(SRC_NATIVE)/org/apache/commons/crypto/OpenSslInfoNative.c $(TARGET)/jni-classes/org/apache/commons/crypto/OpenSslInfoNative.h
 	@mkdir -p $(@D)
-	$(CC) $(CFLAGS) -DVERSION='"$(VERSION)"' -DPROJECT_NAME='"$(PROJECT_NAME)"' -I"$(TARGET)/jni-classes/org/apache/commons/crypto" -c $< -o $@
+	$(CC) $(CFLAGS) -DOPENSSL_API_COMPAT=$(OPENSSL_VERSION) -DVERSION='"$(VERSION)"' -DPROJECT_NAME='"$(PROJECT_NAME)"' -I"$(TARGET)/jni-classes/org/apache/commons/crypto" -c $< -o $@
 
 $(COMMONS_CRYPTO_OUT)/$(LIBNAME): $(COMMONS_CRYPTO_OBJ)
 	$(CXX) $(CXXFLAGS) -o $@ $+ $(LINKFLAGS)

--- a/Makefile.common
+++ b/Makefile.common
@@ -31,6 +31,13 @@ ifndef JAVA_HOME
 $(error Set JAVA_HOME environment variable)
 endif
 
+OPENSSL_VERSION_MAJOR :=$(shell openssl version |cut -d " " -f2|cut -d "." -f1 )
+OPENSSL_VERSION_MINOR :=$(shell openssl version |cut -d " " -f2|cut -d "." -f2 )
+ifneq ($(and $(OPENSSL_VERSION_MAJOR),$(OPENSSL_VERSION_MINOR),1),)
+OPENSSL_VERSION :=0x10100000L
+else
+OPENSSL_VERSION :=0x10000000L
+endif
 JAVA  := "$(JAVA_HOME)/bin/java"
 JAVAC := "$(JAVA_HOME)/bin/javac"
 JAVAH := "$(JAVA_HOME)/bin/javah"
@@ -73,7 +80,6 @@ Default_CXXFLAGS     := -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibil
 Default_LINKFLAGS    := -shared -static
 Default_LIBNAME      := libcommons-crypto.so
 Default_COMMONS_CRYPTO_FLAGS :=
-
 Linux-x86_CC        := $(CROSS_PREFIX)gcc
 Linux-x86_CXX       := $(CROSS_PREFIX)g++
 Linux-x86_STRIP     := $(CROSS_PREFIX)strip
@@ -82,7 +88,6 @@ Linux-x86_CFLAGS    := -I$(JAVA_HOME)/include -O2 -fPIC -fvisibility=hidden -m32
 Linux-x86_LINKFLAGS := -shared -static-libgcc -static-libstdc++
 Linux-x86_LIBNAME   := libcommons-crypto.so
 Linux-x86_COMMONS_CRYPTO_FLAGS:=
-
 Linux-x86_64_CC        := $(CROSS_PREFIX)gcc
 Linux-x86_64_CXX       := $(CROSS_PREFIX)g++
 Linux-x86_64_STRIP     := $(CROSS_PREFIX)strip
@@ -168,6 +173,14 @@ Linux-armhf_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I$(JAVA_HOME)/include 
 Linux-armhf_LINKFLAGS := -shared -static-libgcc
 Linux-armhf_LIBNAME   := libcommons-crypto.so
 Linux-armhf_COMMONS_CRYPTO_FLAGS:=
+Linux-aarch64_CC        := $(CROSS_PREFIX)gcc
+Linux-aarch64_CXX       := $(CROSS_PREFIX)g++
+Linux-aarch64_STRIP     := $(CROSS_PREFIX)strip
+Linux-aarch64_CFLAGS    := -include lib/inc_linux/jni_md.h -I$(JAVA_HOME)/include -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
+Linux-aarch64_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I$(JAVA_HOME)/include -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
+Linux-aarch64_LINKFLAGS := -shared -static-libgcc
+Linux-aarch64_LIBNAME   := libcommons-crypto.so
+Linux-aarch64_COMMONS_CRYPTO_FLAGS:=
 
 Mac-x86_CC        := gcc -arch i386
 Mac-x86_CXX       := g++ -arch i386

--- a/Makefile.common
+++ b/Makefile.common
@@ -36,7 +36,7 @@ OPENSSL_VERSION_MINOR :=$(shell openssl version |cut -d " " -f2|cut -d "." -f2 )
 ifneq ($(and $(OPENSSL_VERSION_MAJOR),$(OPENSSL_VERSION_MINOR),1),)
 OPENSSL_VERSION :=0x10100000L
 else
-OPENSSL_VERSION :=0x10000000L
+$(error Set OPENSSL VERSION 1.1.0 or above in environment variable)
 endif
 JAVA  := "$(JAVA_HOME)/bin/java"
 JAVAC := "$(JAVA_HOME)/bin/javac"

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-crypto</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Apache Commons Crypto</name>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ The following provides more details on the included cryptographic software:
     <commons.release.version>1.0.0</commons.release.version>
     <commons.release.desc>(Requires Java ${maven.compiler.target} or later)</commons.release.desc>
     <commons.rc.version>RC1</commons.rc.version>
-    <jna.version>4.2.2</jna.version>
+    <jna.version>4.4.0</jna.version>
 
     <!-- properties not related to versioning -->
     <commons.jira.id>CRYPTO</commons.jira.id>
@@ -146,8 +146,8 @@ The following provides more details on the included cryptographic software:
     <target.name>all</target.name>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <junit.version>4.12</junit.version>
-    <commons-logging.version>1.1.3</commons-logging.version>
-    <commons.jacoco.version>0.7.7.201606060606</commons.jacoco.version>
+    <commons-logging.version>1.2</commons-logging.version>
+    <commons.jacoco.version>0.8.0</commons.jacoco.version>
     <slf4j-api.version>1.7.10</slf4j-api.version>
 
     <!-- Override default buildNumber timestamp format, needed for coveralls plugin -->

--- a/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCipher.java
+++ b/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCipher.java
@@ -300,7 +300,7 @@ class OpenSslJnaCipher implements CryptoCipher {
     @Override
     public void close() {
         if (context != null) {
-            OpenSslNativeJna.EVP_CIPHER_CTX_cleanup(context);
+	     OpenSslNativeJna.EVP_CIPHER_CTX_reset(context);
             // Freeing the context multiple times causes a JVM crash
             // A work-round is to only free it at finalize time
             // TODO is that sufficient?
@@ -317,7 +317,7 @@ class OpenSslJnaCipher implements CryptoCipher {
             String errdesc = OpenSslNativeJna.ERR_error_string(err, null);
             
             if (context != null) {
-                OpenSslNativeJna.EVP_CIPHER_CTX_cleanup(context);
+                OpenSslNativeJna.EVP_CIPHER_CTX_reset(context);
             }
             throw new RuntimeException("return code "+retVal+" from OpenSSL. Err code is "+err+": "+errdesc);
         }

--- a/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCryptoRandom.java
@@ -65,7 +65,7 @@ class OpenSslJnaCryptoRandom extends Random implements CryptoRandom {
 
         boolean rdrandLoaded = false;
         try {
-            OpenSslNativeJna.ENGINE_load_rdrand();
+	    //OpenSslNativeJna.ENGINE_load_rdrand(); /* Not supported in openssl-1.1.x   */
             rdrandEngine = OpenSslNativeJna.ENGINE_by_id("rdrand");
             int ENGINE_METHOD_RAND = 0x0008;
             if(rdrandEngine != null) {
@@ -101,8 +101,8 @@ class OpenSslJnaCryptoRandom extends Random implements CryptoRandom {
         synchronized (OpenSslJnaCryptoRandom.class) {
             //this method is synchronized for now
             //to support multithreading https://wiki.openssl.org/index.php/Manual:Threads(3) needs to be done
-            
-            if(rdrandEnabled && OpenSslNativeJna.RAND_get_rand_method().equals(OpenSslNativeJna.RAND_SSLeay())) {
+            if(rdrandEnabled && OpenSslNativeJna.RAND_get_rand_method().equals(OpenSslNativeJna.RAND_OpenSSL())) 
+	    {
                 close();
                 throw new RuntimeException("rdrand should be used but default is detected");
             }
@@ -158,8 +158,6 @@ class OpenSslJnaCryptoRandom extends Random implements CryptoRandom {
     @Override
     public void close() {
         closeRdrandEngine();
-        OpenSslNativeJna.ENGINE_cleanup();
-        
         //cleanup locks
         //OpenSslNativeJna.CRYPTO_set_locking_callback(null);
         //LOCK.unlock();

--- a/src/main/java/org/apache/commons/crypto/jna/OpenSslNativeJna.java
+++ b/src/main/java/org/apache/commons/crypto/jna/OpenSslNativeJna.java
@@ -17,7 +17,6 @@
  */
 
 package org.apache.commons.crypto.jna;
-
 import java.nio.ByteBuffer;
 
 import com.sun.jna.Native;
@@ -36,11 +35,10 @@ class OpenSslNativeJna {
     static final Throwable INIT_ERROR;
 
     static {
-        boolean ok = false;
-        Throwable thrown = null;
-        try {
-            Native.register("crypto");
-            ERR_load_crypto_strings();
+	     boolean ok = false;
+	     Throwable thrown = null;
+	     try {
+		    Native.register("crypto");
             ok = true;
         } catch (Exception e) {
             thrown = e;
@@ -57,7 +55,7 @@ class OpenSslNativeJna {
      * @return OPENSSL_VERSION_NUMBER which is a numeric release version
      * * identifier
      */
-    public static native NativeLong SSLeay();
+    public static native NativeLong OpenSSL_version_num();
 
     /**
      * Retrieves version/build information about OpenSSL library.
@@ -66,13 +64,10 @@ class OpenSslNativeJna {
      * @return A pointer to a constant string describing the version of the
      * OpenSSL library or giving information about the library build.
      */
-    public static native String SSLeay_version(int type);
-
-    /**
+    public static native String OpenSSL_version(int type);
+     /**
      * Registers the error strings for all libcrypto functions.
      */
-    public static native void ERR_load_crypto_strings();
-
     /**
      * @return the earliest error code from the thread's error queue without
      * modifying it.
@@ -102,12 +97,6 @@ class OpenSslNativeJna {
      */
     public static native PointerByReference EVP_CIPHER_CTX_new();
 
-
-    /**
-     * EVP_CIPHER_CTX_init() remains as an alias for EVP_CIPHER_CTX_reset
-     * @param p cipher context
-     */
-    public static native void EVP_CIPHER_CTX_init(PointerByReference p);
 
     /**
      * Enables or disables padding
@@ -194,21 +183,18 @@ class OpenSslNativeJna {
      * * memory associate with it.
      * @param c openssl evp cipher
      */
-    public static native void EVP_CIPHER_CTX_cleanup(PointerByReference c);
-
+    public static native void EVP_CIPHER_CTX_reset(PointerByReference c);
     //Random generator
     /**
      * OpenSSL uses for random number generation
      * @return pointers to the respective methods
      */
     public static native PointerByReference RAND_get_rand_method();
-
     /**
      * OpenSSL uses for random number generation.
      * @return pointers to the respective methods
      */
-    public static native PointerByReference RAND_SSLeay();
-
+    public static native PointerByReference RAND_OpenSSL();
     /**
      * Generates random data
      * @param buf the bytes for generated random.
@@ -233,17 +219,15 @@ class OpenSslNativeJna {
     public static native int ENGINE_free(PointerByReference e);
 
     /**
-     * Cleanups before program exit, it will avoid memory leaks.
-     * @return 0 on success, 1 otherwise.
-     */
-    public static native int ENGINE_cleanup();
-
-    /**
      * Obtains a functional reference from an existing structural reference.
      * @param e engine reference
      * @return zero if the ENGINE was not already operational and couldn't be successfully initialised
      */
     public static native int ENGINE_init(PointerByReference e);
+     /**
+     * Cleanups before program exit, it will avoid memory leaks.
+     * @return 0 on success, 1 otherwise.
+     */
 
     /**
      * Sets the engine as the default for random number generation.
@@ -260,10 +244,6 @@ class OpenSslNativeJna {
      */
     public static native PointerByReference ENGINE_by_id(String id);
 
-    /**
-     * Initializes the engine.
-     */
-    public static native void ENGINE_load_rdrand();
 
     //TODO callback multithreading
     /*public interface Id_function_cb extends Callback {

--- a/src/main/native/org/apache/commons/crypto/cipher/OpenSslNative.c
+++ b/src/main/native/org/apache/commons/crypto/cipher/OpenSslNative.c
@@ -32,8 +32,12 @@
 #ifdef UNIX
 static EVP_CIPHER_CTX * (*dlsym_EVP_CIPHER_CTX_new)(void);
 static void (*dlsym_EVP_CIPHER_CTX_free)(EVP_CIPHER_CTX *);
+#if OPENSSL_API_COMPAT < 0x10100000L
 static int (*dlsym_EVP_CIPHER_CTX_cleanup)(EVP_CIPHER_CTX *);
 static void (*dlsym_EVP_CIPHER_CTX_init)(EVP_CIPHER_CTX *);
+#else
+static void (*dlsym_EVP_CIPHER_CTX_reset)(EVP_CIPHER_CTX *);
+#endif
 static int (*dlsym_EVP_CIPHER_CTX_set_padding)(EVP_CIPHER_CTX *, int);
 static int (*dlsym_EVP_CIPHER_CTX_ctrl)(EVP_CIPHER_CTX *, int, int, void *);
 static int (*dlsym_EVP_CipherInit_ex)(EVP_CIPHER_CTX *, const EVP_CIPHER *,  \
@@ -168,10 +172,15 @@ JNIEXPORT void JNICALL Java_org_apache_commons_crypto_cipher_OpenSslNative_initI
                       "EVP_CIPHER_CTX_new");
   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_free, env, openssl,  \
                       "EVP_CIPHER_CTX_free");
+#if OPENSSL_API_COMPAT < 0x10100000L
   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_cleanup, env, openssl,  \
                       "EVP_CIPHER_CTX_cleanup");
   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_init, env, openssl,  \
                       "EVP_CIPHER_CTX_init");
+#else
+  LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_reset, env, openssl,  \
+                      "EVP_CIPHER_CTX_reset");
+#endif
   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_set_padding, env, openssl,  \
                       "EVP_CIPHER_CTX_set_padding");
   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_CIPHER_CTX_ctrl, env, openssl,  \
@@ -372,7 +381,11 @@ JNIEXPORT jlong JNICALL Java_org_apache_commons_crypto_cipher_OpenSslNative_init
 cleanup:
   if (result == 0 && context != NULL) {
     if (CONTEXT(ctx) != NULL) {
+#if OPENSSL_API_COMPAT < 0x10100000L
       dlsym_EVP_CIPHER_CTX_cleanup(context);
+#else
+      dlsym_EVP_CIPHER_CTX_reset(context);
+#endif
     } else {
       dlsym_EVP_CIPHER_CTX_free(context);
     }
@@ -391,14 +404,25 @@ cleanup:
 static int check_update_max_output_len(EVP_CIPHER_CTX *context, int input_len,
     int max_output_len)
 {
-  if (context->flags & EVP_CIPH_NO_PADDING) {
+#if OPENSSL_API_COMPAT < 0x10100000L
+  if (context->flags & EVP_CIPH_NO_PADDING)
+#else
+  if (EVP_CIPHER_CTX_test_flags(context, EVP_CIPH_NO_PADDING)) 
+#endif
+   {
     if (max_output_len >= input_len) {
       return 1;
     }
     return 0;
   } else {
+#if OPENSSL_API_COMPAT < 0x10100000L
     int b = context->cipher->block_size;
-    if (context->encrypt) {
+    if (context->encrypt)
+#else
+    int b = EVP_CIPHER_CTX_block_size(context);
+    if (EVP_CIPHER_CTX_encrypting(context))
+#endif
+     {
       if (max_output_len >= input_len + b - 1) {
         return 1;
       }
@@ -434,7 +458,11 @@ JNIEXPORT jint JNICALL Java_org_apache_commons_crypto_cipher_OpenSslNative_updat
   int output_len = 0;
   if (!dlsym_EVP_CipherUpdate(context, output_bytes, &output_len,  \
       input_bytes, input_len)) {
+#if OPENSSL_API_COMPAT < 0x10100000L
     dlsym_EVP_CIPHER_CTX_cleanup(context);
+#else
+    dlsym_EVP_CIPHER_CTX_reset(context);
+#endif
     THROW(env, "java/lang/InternalError", "Error in EVP_CipherUpdate.");
     return 0;
   }
@@ -473,7 +501,11 @@ JNIEXPORT jint JNICALL Java_org_apache_commons_crypto_cipher_OpenSslNative_updat
   int rc = dlsym_EVP_CipherUpdate(context, output_bytes + output_offset, &output_len,  \
       input_bytes + input_offset, input_len);
   if (rc == 0) {
+#if OPENSSL_API_COMPAT < 0x10100000L
     dlsym_EVP_CIPHER_CTX_cleanup(context);
+#else
+    dlsym_EVP_CIPHER_CTX_reset(context);
+#endif
     THROW(env, "java/lang/InternalError", "Error in EVP_CipherUpdate.");
     output_len = 0;
   }
@@ -512,7 +544,11 @@ JNIEXPORT jint JNICALL Java_org_apache_commons_crypto_cipher_OpenSslNative_updat
   if (!dlsym_EVP_CipherUpdate(context, output_bytes, &output_len,  \
       input_bytes, input_len)) {
     (*env)->ReleaseByteArrayElements(env, input, (jbyte *) input_bytes, 0);
+#if OPENSSL_API_COMPAT < 0x10100000L
     dlsym_EVP_CIPHER_CTX_cleanup(context);
+#else
+    dlsym_EVP_CIPHER_CTX_reset(context);
+#endif
     THROW(env, "java/lang/InternalError", "Error in EVP_CipherUpdate.");
     return 0;
   }
@@ -524,10 +560,19 @@ JNIEXPORT jint JNICALL Java_org_apache_commons_crypto_cipher_OpenSslNative_updat
 static int check_doFinal_max_output_len(EVP_CIPHER_CTX *context,
     int max_output_len)
 {
-  if (context->flags & EVP_CIPH_NO_PADDING) {
+#if OPENSSL_API_COMPAT < 0x10100000L
+  if (context->flags & EVP_CIPH_NO_PADDING)
+#else
+  if (EVP_CIPHER_CTX_test_flags(context,EVP_CIPH_NO_PADDING))
+#endif 
+   {
     return 1;
   } else {
+#if OPENSSL_API_COMPAT < 0x10100000L
     int b = context->cipher->block_size;
+#else
+    int b = EVP_CIPHER_CTX_block_size(context);
+#endif
     if (max_output_len >= b) {
       return 1;
     }
@@ -556,13 +601,24 @@ JNIEXPORT jint JNICALL Java_org_apache_commons_crypto_cipher_OpenSslNative_doFin
   int output_len = 0;
   if (!dlsym_EVP_CipherFinal_ex(context, output_bytes, &output_len)) {
     // validate tag in GCM mode when decrypt
+#if OPENSSL_API_COMPAT < 0x10100000L
     if ((context->cipher->flags & EVP_CIPH_MODE) == EVP_CIPH_GCM_MODE
-        && context->encrypt == DECRYPT_MODE) {
+        && context->encrypt == DECRYPT_MODE)
+#else
+    if (((EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(context)) & EVP_CIPH_MODE) 
+        == EVP_CIPH_GCM_MODE) && 
+       (EVP_CIPHER_CTX_encrypting(context) ==  DECRYPT_MODE))
+#endif 
+    {
       THROW(env, "javax/crypto/AEADBadTagException", "Tag mismatch!");
     } else {
       THROW(env, "java/lang/InternalError", "Error in EVP_CipherFinal_ex.");
     }
+#if OPENSSL_API_COMPAT < 0x10100000L
     dlsym_EVP_CIPHER_CTX_cleanup(context);
+#else
+    dlsym_EVP_CIPHER_CTX_reset(context);
+#endif
     return 0;
   }
   return output_len;
@@ -591,13 +647,23 @@ JNIEXPORT jint JNICALL Java_org_apache_commons_crypto_cipher_OpenSslNative_doFin
 
   if (rc == 0) {
     // validate tag in GCM mode when decrypt
+#if OPENSSL_API_COMPAT < 0x10100000L
     if ((context->cipher->flags & EVP_CIPH_MODE) == EVP_CIPH_GCM_MODE
-      && context->encrypt == DECRYPT_MODE) {
+      && context->encrypt == DECRYPT_MODE)
+#else
+    if ((EVP_CIPHER_flags(EVP_CIPHER_CTX_cipher(context)) & EVP_CIPH_MODE) == EVP_CIPH_GCM_MODE
+      && EVP_CIPHER_CTX_encrypting(context) == DECRYPT_MODE)
+#endif 
+    {
     THROW(env, "javax/crypto/AEADBadTagException", "Tag mismatch!");
     } else {
     THROW(env, "java/lang/InternalError", "Error in EVP_CipherFinal_ex.");
     }
+#if OPENSSL_API_COMPAT < 0x10100000L
     dlsym_EVP_CIPHER_CTX_cleanup(context);
+#else
+    dlsym_EVP_CIPHER_CTX_reset(context);
+#endif
     return 0;
   }
   return output_len;

--- a/src/main/native/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.c
+++ b/src/main/native/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.c
@@ -43,16 +43,20 @@
 #ifdef UNIX
 static void * (*dlsym_CRYPTO_malloc) (int, const char *, int);
 static void (*dlsym_CRYPTO_free) (void *);
+#if OPENSSL_API_COMPAT < 0x10100000L
 static int (*dlsym_CRYPTO_num_locks) (void);
 static void (*dlsym_CRYPTO_set_locking_callback) (void (*)());
 static void (*dlsym_CRYPTO_set_id_callback) (unsigned long (*)());
 static void (*dlsym_ENGINE_load_rdrand) (void);
+#endif
 static ENGINE * (*dlsym_ENGINE_by_id) (const char *);
 static int (*dlsym_ENGINE_init) (ENGINE *);
 static int (*dlsym_ENGINE_set_default) (ENGINE *, unsigned int);
 static int (*dlsym_ENGINE_finish) (ENGINE *);
 static int (*dlsym_ENGINE_free) (ENGINE *);
+#if OPENSSL_API_COMPAT < 0x10100000L
 static void (*dlsym_ENGINE_cleanup) (void);
+#endif
 static int (*dlsym_RAND_bytes) (unsigned char *, int);
 static unsigned long (*dlsym_ERR_get_error) (void);
 #endif
@@ -120,6 +124,7 @@ JNIEXPORT void JNICALL Java_org_apache_commons_crypto_random_OpenSslCryptoRandom
   dlerror();  // Clear any existing error
   LOAD_DYNAMIC_SYMBOL(dlsym_CRYPTO_malloc, env, openssl, "CRYPTO_malloc");
   LOAD_DYNAMIC_SYMBOL(dlsym_CRYPTO_free, env, openssl, "CRYPTO_free");
+#if OPENSSL_API_COMPAT < 0x10100000L
   LOAD_DYNAMIC_SYMBOL(dlsym_CRYPTO_num_locks, env, openssl, "CRYPTO_num_locks");
   LOAD_DYNAMIC_SYMBOL(dlsym_CRYPTO_set_locking_callback,  \
                       env, openssl, "CRYPTO_set_locking_callback");
@@ -127,13 +132,14 @@ JNIEXPORT void JNICALL Java_org_apache_commons_crypto_random_OpenSslCryptoRandom
                       openssl, "CRYPTO_set_id_callback");
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_load_rdrand, env,  \
                       openssl, "ENGINE_load_rdrand");
+  LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_cleanup, env, openssl, "ENGINE_cleanup");
+#endif
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_by_id, env, openssl, "ENGINE_by_id");
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_init, env, openssl, "ENGINE_init");
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_set_default, env,  \
                       openssl, "ENGINE_set_default");
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_finish, env, openssl, "ENGINE_finish");
   LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_free, env, openssl, "ENGINE_free");
-  LOAD_DYNAMIC_SYMBOL(dlsym_ENGINE_cleanup, env, openssl, "ENGINE_cleanup");
   LOAD_DYNAMIC_SYMBOL(dlsym_RAND_bytes, env, openssl, "RAND_bytes");
   LOAD_DYNAMIC_SYMBOL(dlsym_ERR_get_error, env, openssl, "ERR_get_error");
 #endif
@@ -240,12 +246,12 @@ static void windows_locking_callback(int mode, int type, char *file, int line)
   }
 }
 #endif /* WINDOWS */
-
 #ifdef UNIX
-static void pthreads_locking_callback(int mode, int type, char *file, int line);
 static unsigned long pthreads_thread_id(void);
-static pthread_mutex_t *lock_cs;
 
+#if OPENSSL_API_COMPAT < 0x10100000L
+static pthread_mutex_t *lock_cs;
+static void pthreads_locking_callback(int mode, int type, char *file, int line);
 static void locks_setup(void)
 {
   int i;
@@ -271,7 +277,6 @@ static void locks_cleanup(void)
 
   dlsym_CRYPTO_free(lock_cs);
 }
-
 static void pthreads_locking_callback(int mode, int type, char *file, int line)
 {
   UNUSED(file), UNUSED(line);
@@ -282,7 +287,7 @@ static void pthreads_locking_callback(int mode, int type, char *file, int line)
     pthread_mutex_unlock(&(lock_cs[type]));
   }
 }
-
+#endif
 static unsigned long pthreads_thread_id(void)
 {
   return (unsigned long)syscall(SYS_gettid);
@@ -296,9 +301,10 @@ static unsigned long pthreads_thread_id(void)
  */
 static ENGINE * openssl_rand_init(void)
 {
+#if OPENSSL_API_COMPAT < 0x10100000L
   locks_setup();
-
   dlsym_ENGINE_load_rdrand();
+#endif
   ENGINE *eng = dlsym_ENGINE_by_id("rdrand");
 
   int ret = -1;
@@ -333,11 +339,12 @@ static void openssl_rand_clean(ENGINE *eng, int clean_locks)
     dlsym_ENGINE_finish(eng);
     dlsym_ENGINE_free(eng);
   }
-
+#if OPENSSL_API_COMPAT < 0x10100000L
   dlsym_ENGINE_cleanup();
   if (clean_locks) {
     locks_cleanup();
   }
+#endif
 }
 
 static int openssl_rand_bytes(unsigned char *buf, int num)

--- a/src/test/java/org/apache/commons/crypto/jna/OpenSslNativeJnaTest.java
+++ b/src/test/java/org/apache/commons/crypto/jna/OpenSslNativeJnaTest.java
@@ -25,7 +25,7 @@ public class OpenSslNativeJnaTest {
     @Test
     public void test() {
         if (OpenSslJna.isEnabled()) {
-            System.out.println("** INFO: JNA is using: " + OpenSslNativeJna.SSLeay_version(0));
+            System.out.println("** INFO: JNA is using: " + OpenSslNativeJna.OpenSSL_version(0));
         } else {
             System.out.println("** WARN: JNA could not be enabled: " + OpenSslJna.initialisationError().getMessage());
         }


### PR DESCRIPTION
AARCH 64 architecture support was missing in the exiting common-crypto code.
After these modifcation now the common-crypto project can be used in aarch64
platform and also compatible with openssl 1.1.x.