### PR TITLE
Cleanup tests to not catch exceptions unnecessarily.

### DIFF
--- a/src/test/java/org/apache/commons/crypto/cipher/AbstractCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/AbstractCipherTest.java
@@ -20,7 +20,6 @@ package org.apache.commons.crypto.cipher;
 import static org.junit.Assert.assertNotNull;
 
 import java.nio.ByteBuffer;
-import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.Properties;
 import java.util.Random;
@@ -114,7 +113,7 @@ public abstract class AbstractCipherTest {
     }
 
     @Test
-    public void cryptoTest() throws GeneralSecurityException {
+    public void cryptoTest() throws Exception {
         for (String tran : transformations) {
             /** uses the small data set in {@link TestData} */
             cipherTests = TestData.getTestData(tran);
@@ -150,27 +149,17 @@ public abstract class AbstractCipherTest {
 
     private void byteBufferTest(String transformation,
             byte[] key, byte[] iv, ByteBuffer input, ByteBuffer output)
-            throws GeneralSecurityException {
+            throws Exception {
         ByteBuffer decResult = ByteBuffer.allocateDirect(BYTEBUFFER_SIZE);
         ByteBuffer encResult = ByteBuffer.allocateDirect(BYTEBUFFER_SIZE);
-        CryptoCipher enc, dec;
 
-        enc = getCipher(transformation);
-        dec = getCipher(transformation);
+        CryptoCipher enc = getCipher(transformation);
+        enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"),
+                new IvParameterSpec(iv));
 
-        try {
-            enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"),
-                    new IvParameterSpec(iv));
-        } catch (Exception e) {
-            Assert.fail("AES failed initialisation - " + e.toString());
-        }
-
-        try {
-            dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"),
-                    new IvParameterSpec(iv));
-        } catch (Exception e) {
-            Assert.fail("AES failed initialisation - " + e.toString());
-        }
+        CryptoCipher dec = getCipher(transformation);
+        dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"),
+                new IvParameterSpec(iv));
 
         //
         // encryption pass
@@ -206,7 +195,7 @@ public abstract class AbstractCipherTest {
     /** test byte array whose data is planned in {@link TestData} */
     private void byteArrayTest(String transformation, byte[] key,
             byte[] iv, byte[] input, byte[] output)
-            throws GeneralSecurityException {
+            throws Exception {
         resetCipher(transformation, key, iv);
         int blockSize = enc.getBlockSize();
 
@@ -227,7 +216,7 @@ public abstract class AbstractCipherTest {
 
     /** test byte array whose data is randomly generated */
     private void byteArrayTest(String transformation, byte[] key,
-            byte[] iv) throws GeneralSecurityException {
+            byte[] iv) throws Exception {
         int blockSize = enc.getBlockSize();
 
         // AES_CBC_NOPADDING only accepts data whose size is the multiple of
@@ -283,34 +272,20 @@ public abstract class AbstractCipherTest {
         }
     }
 
-    private void resetCipher(String transformation, byte[] key,
-            byte[] iv) {
+    private void resetCipher(String transformation, byte[] key, byte[] iv) throws Exception {
         enc = getCipher(transformation);
         dec = getCipher(transformation);
 
-        try {
-            enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"),
-                    new IvParameterSpec(iv));
-        } catch (Exception e) {
-            Assert.fail("AES failed initialisation - " + e.toString());
-        }
+        enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"),
+                new IvParameterSpec(iv));
 
-        try {
-            dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"),
-                    new IvParameterSpec(iv));
-        } catch (Exception e) {
-            Assert.fail("AES failed initialisation - " + e.toString());
-        }
+        dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"),
+                new IvParameterSpec(iv));
     }
 
-    private CryptoCipher getCipher(String transformation) {
-        try {
-            return (CryptoCipher) ReflectionUtils.newInstance(
-                    ReflectionUtils.getClassByName(cipherClass), props,
-                    transformation);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-
+    private CryptoCipher getCipher(String transformation) throws Exception {
+        return (CryptoCipher) ReflectionUtils.newInstance(
+                ReflectionUtils.getClassByName(cipherClass), props,
+                transformation);
     }
 }

--- a/src/test/java/org/apache/commons/crypto/cipher/GcmCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/GcmCipherTest.java
@@ -63,7 +63,7 @@ public class GcmCipherTest {
      * http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf
      */
     @Test
-    public void testGcmNistCase2() {
+    public void testGcmNistCase2() throws Exception {
         // key length:          16 bytes
         // plain text length:   16 bytes
         // iv length:           12 bytes
@@ -85,7 +85,7 @@ public class GcmCipherTest {
     }
 
     @Test
-    public void testGcmNistCase4() {
+    public void testGcmNistCase4() throws Exception {
         // key length:          16 bytes
         // plain text length:   60 bytes
         // iv length:           12 bytes
@@ -114,7 +114,7 @@ public class GcmCipherTest {
     }
 
     @Test
-    public void testGcmNistCase5(){
+    public void testGcmNistCase5() throws Exception {
         // key length:          16 bytes
         // plain text length:   60 bytes
         // iv length:           8 bytes
@@ -147,7 +147,7 @@ public class GcmCipherTest {
     }
 
     @Test
-    public void testGcmNistCase6(){
+    public void testGcmNistCase6() throws Exception {
         // key length:          16 bytes
         // plain text length:   60 bytes
         // iv length:           60 bytes
@@ -183,7 +183,7 @@ public class GcmCipherTest {
     }
 
     @Test
-    public void testGcmNistCases(){
+    public void testGcmNistCases() throws Exception {
         for(int i = 0; i < kHex.length; i++) {
             testGcmEncryption(kHex[i], pHex[i], ivHex[i], aadHex[i], cHex[i], tHex[i]);
             testGcmDecryption(kHex[i], pHex[i], ivHex[i], aadHex[i], cHex[i], tHex[i]);
@@ -216,7 +216,7 @@ public class GcmCipherTest {
         byte[] encOutput = new byte[plainBytes.length + (tagLength >> 3)];
         byte[] decOutput = new byte[plainBytes.length];
 
-        try {
+        {
             CryptoCipher c = Utils.getCipherInstance(transformation, props);
             Key key = new SecretKeySpec(keyBytes, "AES");
 
@@ -225,9 +225,6 @@ public class GcmCipherTest {
             c.updateAAD(aadBytes);
             c.doFinal(plainBytes, 0, plainBytes.length, encOutput, 0);
             c.close();
-        }
-        catch (Exception ex) {
-            Assert.fail(ex.getMessage());
         }
 
         // Tamper the encrypted data.
@@ -250,7 +247,7 @@ public class GcmCipherTest {
     }
 
     @Test
-    public void testGMac() {
+    public void testGMac() throws Exception {
         // for GMAC,  aad is the input data,
         // tag is the digest message
 
@@ -270,43 +267,38 @@ public class GcmCipherTest {
         r.nextBytes(ivBytes);
         r.nextBytes(aad);
 
-        try {
-            {
-                Cipher c = Cipher.getInstance(transformation);
-                Key key = new SecretKeySpec(keyBytes, "AES");
-                GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
-                c.init(Cipher.ENCRYPT_MODE, key, iv);
-                c.updateAAD(aad);
-                c.doFinal(input, 0, input.length, tag_orig, 0);
-            }
-
-            {
-                CryptoCipher c = Utils.getCipherInstance(transformation, props);
-                Key key = new SecretKeySpec(keyBytes, "AES");
-                GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
-                c.init(Cipher.ENCRYPT_MODE, key, iv);
-                c.updateAAD(aad);
-                c.doFinal(input, 0, input.length, tag, 0);
-                c.close();
-            }
-
-            // tag should be the same as JDK's cipher
-            Assert.assertArrayEquals(tag_orig, tag);
-
-            // like JDK's decrypt mode. The plaintext+tag is the input for decrypt mode
-            // let's verify the add & tag now
-            {
-                CryptoCipher c = Utils.getCipherInstance(transformation, props);
-                Key key = new SecretKeySpec(keyBytes, "AES");
-                GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
-                c.init(Cipher.DECRYPT_MODE, key, iv);
-                c.updateAAD(aad);
-                c.doFinal(tag, 0, tag.length, input, 0);
-                c.close();
-            }
+        {
+            Cipher c = Cipher.getInstance(transformation);
+            Key key = new SecretKeySpec(keyBytes, "AES");
+            GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
+            c.init(Cipher.ENCRYPT_MODE, key, iv);
+            c.updateAAD(aad);
+            c.doFinal(input, 0, input.length, tag_orig, 0);
         }
-        catch (Exception ex) {
-            Assert.fail(ex.getMessage());
+
+        {
+            CryptoCipher c = Utils.getCipherInstance(transformation, props);
+            Key key = new SecretKeySpec(keyBytes, "AES");
+            GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
+            c.init(Cipher.ENCRYPT_MODE, key, iv);
+            c.updateAAD(aad);
+            c.doFinal(input, 0, input.length, tag, 0);
+            c.close();
+        }
+
+        // tag should be the same as JDK's cipher
+        Assert.assertArrayEquals(tag_orig, tag);
+
+        // like JDK's decrypt mode. The plaintext+tag is the input for decrypt mode
+        // let's verify the add & tag now
+        {
+            CryptoCipher c = Utils.getCipherInstance(transformation, props);
+            Key key = new SecretKeySpec(keyBytes, "AES");
+            GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
+            c.init(Cipher.DECRYPT_MODE, key, iv);
+            c.updateAAD(aad);
+            c.doFinal(tag, 0, tag.length, input, 0);
+            c.close();
         }
     }
 
@@ -326,7 +318,7 @@ public class GcmCipherTest {
         r.nextBytes(ivBytes);
         r.nextBytes(aad);
 
-        try {
+        {
             CryptoCipher c = Utils.getCipherInstance(transformation, props);
             Key key = new SecretKeySpec(keyBytes, "AES");
             GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
@@ -334,9 +326,6 @@ public class GcmCipherTest {
             c.updateAAD(aad);
             c.doFinal(input, 0, input.length, tag, 0);
             c.close();
-        }
-        catch (Exception ex) {
-            Assert.fail(ex.getMessage());
         }
 
         try {
@@ -358,13 +347,10 @@ public class GcmCipherTest {
             Assert.assertTrue("Tag mismatch!".equals(ex.getMessage()));
             throw ex;
         }
-        catch (Exception ex) {
-            Assert.fail(ex.getMessage());
-        }
     }
 
     private void testGcmEncryption(String kHex, String pHex, String ivHex, String aadHex,
-                                   String cHex, String tHex){
+                                   String cHex, String tHex) throws Exception {
 
         byte[] keyBytes = DatatypeConverter.parseHexBinary(kHex);
         byte[] input = DatatypeConverter.parseHexBinary(pHex);
@@ -374,27 +360,22 @@ public class GcmCipherTest {
 
         byte[] output = new byte[expectedOutput.length];
 
-        try {
-            CryptoCipher c = Utils.getCipherInstance(transformation, props);
+        CryptoCipher c = Utils.getCipherInstance(transformation, props);
 
-            Key key = new SecretKeySpec(keyBytes, "AES");
+        Key key = new SecretKeySpec(keyBytes, "AES");
 
-            GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
-            c.init(Cipher.ENCRYPT_MODE, key, iv);
-            c.updateAAD(aad);
+        GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
+        c.init(Cipher.ENCRYPT_MODE, key, iv);
+        c.updateAAD(aad);
 
-            c.doFinal(input, 0, input.length, output, 0);
+        c.doFinal(input, 0, input.length, output, 0);
 
-            Assert.assertArrayEquals(expectedOutput, output);
-            c.close();
-        }
-        catch (Exception ex) {
-            Assert.fail(ex.getMessage());
-        }
+        Assert.assertArrayEquals(expectedOutput, output);
+        c.close();
     }
 
     private void testGcmArbitraryLengthUpdate(String kHex, String pHex, String ivHex, String aadHex,
-                                              String cHex, String tHex){
+                                              String cHex, String tHex) throws Exception {
 
         byte[] keyBytes = DatatypeConverter.parseHexBinary(kHex);
         byte[] input = DatatypeConverter.parseHexBinary(pHex);
@@ -405,58 +386,53 @@ public class GcmCipherTest {
         byte[] encOutput = new byte[expectedOutput.length];
         byte[] decOutput = new byte[input.length];
 
-        try {
-            Random r = new Random();
+        Random r = new Random();
 
-            CryptoCipher enc = Utils.getCipherInstance(transformation, props);
-            Key key = new SecretKeySpec(keyBytes, "AES");
-            GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
-            enc.init(Cipher.ENCRYPT_MODE, key, iv);
-            if (aad.length > 0) {
-                int len1 = r.nextInt(aad.length) ;
-                byte[] aad1 = Arrays.copyOfRange(aad, 0, len1);
-                byte[] aad2 = Arrays.copyOfRange(aad, len1, aad.length);
-                enc.updateAAD(aad1);
-                enc.updateAAD(aad2);
-            }
-
-            int partLen = r.nextInt(input.length);
-            int len = enc.update(input, 0, partLen, encOutput, 0);
-            Assert.assertTrue(len == partLen);
-            len = enc.doFinal(input, partLen, input.length - partLen, encOutput, partLen);
-            Assert.assertTrue(len == (input.length + (iv.getTLen() >> 3) - partLen));
-
-            Assert.assertArrayEquals(expectedOutput, encOutput);
-            enc.close();
-
-            // Decryption
-            CryptoCipher dec = Utils.getCipherInstance(transformation, props);
-            dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, "AES"),
-                    new GCMParameterSpec(128, ivBytes));
-            if (aad.length > 0) {
-                int len1 = r.nextInt(aad.length) ;
-                byte[] aad1 = Arrays.copyOfRange(aad, 0, len1);
-                byte[] aad2 = Arrays.copyOfRange(aad, len1, aad.length);
-                dec.updateAAD(aad1);
-                dec.updateAAD(aad2);
-            }
-            byte[] decInput = encOutput;
-            partLen = r.nextInt(input.length);
-            len = dec.update(decInput, 0, partLen, decOutput, 0);
-            Assert.assertTrue(len == 0);
-            len = dec.doFinal(decInput, partLen, decInput.length - partLen, decOutput, 0);
-            Assert.assertTrue(len == input.length);
-
-            Assert.assertArrayEquals(input, decOutput);
-            dec.close();
+        CryptoCipher enc = Utils.getCipherInstance(transformation, props);
+        Key key = new SecretKeySpec(keyBytes, "AES");
+        GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
+        enc.init(Cipher.ENCRYPT_MODE, key, iv);
+        if (aad.length > 0) {
+            int len1 = r.nextInt(aad.length) ;
+            byte[] aad1 = Arrays.copyOfRange(aad, 0, len1);
+            byte[] aad2 = Arrays.copyOfRange(aad, len1, aad.length);
+            enc.updateAAD(aad1);
+            enc.updateAAD(aad2);
         }
-        catch (Exception ex) {
-            Assert.fail(ex.getMessage());
+
+        int partLen = r.nextInt(input.length);
+        int len = enc.update(input, 0, partLen, encOutput, 0);
+        Assert.assertTrue(len == partLen);
+        len = enc.doFinal(input, partLen, input.length - partLen, encOutput, partLen);
+        Assert.assertTrue(len == (input.length + (iv.getTLen() >> 3) - partLen));
+
+        Assert.assertArrayEquals(expectedOutput, encOutput);
+        enc.close();
+
+        // Decryption
+        CryptoCipher dec = Utils.getCipherInstance(transformation, props);
+        dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, "AES"),
+                new GCMParameterSpec(128, ivBytes));
+        if (aad.length > 0) {
+            int len1 = r.nextInt(aad.length) ;
+            byte[] aad1 = Arrays.copyOfRange(aad, 0, len1);
+            byte[] aad2 = Arrays.copyOfRange(aad, len1, aad.length);
+            dec.updateAAD(aad1);
+            dec.updateAAD(aad2);
         }
+        byte[] decInput = encOutput;
+        partLen = r.nextInt(input.length);
+        len = dec.update(decInput, 0, partLen, decOutput, 0);
+        Assert.assertTrue(len == 0);
+        len = dec.doFinal(decInput, partLen, decInput.length - partLen, decOutput, 0);
+        Assert.assertTrue(len == input.length);
+
+        Assert.assertArrayEquals(input, decOutput);
+        dec.close();
     }
 
     private void testGcmDecryption(String kHex, String pHex, String ivHex, String aadHex,
-                                   String cHex, String tHex){
+                                   String cHex, String tHex) throws Exception {
 
         byte[] keyBytes = DatatypeConverter.parseHexBinary(kHex);
         byte[] plainBytes = DatatypeConverter.parseHexBinary(pHex);
@@ -468,26 +444,21 @@ public class GcmCipherTest {
         byte[] input = cipherBytes;
         byte[] output = new byte[plainBytes.length];
 
-        try {
-            CryptoCipher c = Utils.getCipherInstance(transformation, props);
+        CryptoCipher c = Utils.getCipherInstance(transformation, props);
 
-            Key key = new SecretKeySpec(keyBytes, "AES");
+        Key key = new SecretKeySpec(keyBytes, "AES");
 
-            GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
-            c.init(Cipher.DECRYPT_MODE, key, iv);
-            c.updateAAD(aad);
-            c.doFinal(input, 0, input.length, output, 0);
+        GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
+        c.init(Cipher.DECRYPT_MODE, key, iv);
+        c.updateAAD(aad);
+        c.doFinal(input, 0, input.length, output, 0);
 
-            Assert.assertArrayEquals(plainBytes, output);
-            c.close();
-        }
-        catch (Exception ex) {
-            Assert.fail(ex.getMessage());
-        }
+        Assert.assertArrayEquals(plainBytes, output);
+        c.close();
     }
 
     private void testGcmReturnDataAfterTagVerified(String kHex, String pHex, String ivHex, String aadHex,
-                                                   String cHex, String tHex){
+                                                   String cHex, String tHex) throws Exception {
 
         byte[] keyBytes = DatatypeConverter.parseHexBinary(kHex);
         byte[] plainBytes = DatatypeConverter.parseHexBinary(pHex);
@@ -499,31 +470,26 @@ public class GcmCipherTest {
         byte[] input = cipherBytes;
         byte[] output = new byte[plainBytes.length];
 
-        try {
-            CryptoCipher c = Utils.getCipherInstance(transformation, props);
+        CryptoCipher c = Utils.getCipherInstance(transformation, props);
 
-            Key key = new SecretKeySpec(keyBytes, "AES");
+        Key key = new SecretKeySpec(keyBytes, "AES");
 
-            GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
-            c.init(Cipher.DECRYPT_MODE, key, iv);
-            c.updateAAD(aad);
+        GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
+        c.init(Cipher.DECRYPT_MODE, key, iv);
+        c.updateAAD(aad);
 
-            //only return recovered data after tag is successfully verified
-            int len = c.update(input, 0, input.length, output, 0);
-            Assert.assertTrue(len == 0);
-            len += c.doFinal(input, input.length, 0, output, 0);
-            Assert.assertTrue(len == plainBytes.length);
+        //only return recovered data after tag is successfully verified
+        int len = c.update(input, 0, input.length, output, 0);
+        Assert.assertTrue(len == 0);
+        len += c.doFinal(input, input.length, 0, output, 0);
+        Assert.assertTrue(len == plainBytes.length);
 
-            Assert.assertArrayEquals(plainBytes, output);
-            c.close();
-        }
-        catch (Exception ex) {
-            Assert.fail(ex.getMessage());
-        }
+        Assert.assertArrayEquals(plainBytes, output);
+        c.close();
     }
 
     private void testGcmByteBuffer(String kHex, String pHex, String ivHex, String aadHex,
-                                   String cHex, String tHex){
+                                   String cHex, String tHex) throws Exception {
 
         byte[] keyBytes = DatatypeConverter.parseHexBinary(kHex);
         byte[] plainText = DatatypeConverter.parseHexBinary(pHex);
@@ -534,55 +500,49 @@ public class GcmCipherTest {
         byte[] encOutput = new byte[cipherText.length];
         byte[] decOutput = new byte[plainText.length];
 
-        try {
+        ByteBuffer bfAAD = ByteBuffer.allocateDirect(aad.length);
+        bfAAD.put(aad);
 
-            ByteBuffer bfAAD = ByteBuffer.allocateDirect(aad.length);
-            bfAAD.put(aad);
+        ByteBuffer bfPlainText;
+        ByteBuffer bfCipherText;
+        bfPlainText = ByteBuffer.allocateDirect(plainText.length);
+        bfCipherText = ByteBuffer.allocateDirect(encOutput.length);
 
-            ByteBuffer bfPlainText;
-            ByteBuffer bfCipherText;
-            bfPlainText = ByteBuffer.allocateDirect(plainText.length);
-            bfCipherText = ByteBuffer.allocateDirect(encOutput.length);
+        // Encryption -------------------
+        CryptoCipher c = Utils.getCipherInstance(transformation, props);
+        Key key = new SecretKeySpec(keyBytes, "AES");
+        GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
+        c.init(Cipher.ENCRYPT_MODE, key, iv);
 
-            // Encryption -------------------
-            CryptoCipher c = Utils.getCipherInstance(transformation, props);
-            Key key = new SecretKeySpec(keyBytes, "AES");
-            GCMParameterSpec iv = new GCMParameterSpec(128, ivBytes);
-            c.init(Cipher.ENCRYPT_MODE, key, iv);
+        bfAAD.flip();
+        c.updateAAD(bfAAD);
 
-            bfAAD.flip();
-            c.updateAAD(bfAAD);
+        bfPlainText.put(plainText);
+        bfPlainText.flip();
+        bfCipherText.position(0);
 
-            bfPlainText.put(plainText);
-            bfPlainText.flip();
-            bfCipherText.position(0);
+        c.doFinal(bfPlainText, bfCipherText);
 
-            c.doFinal(bfPlainText, bfCipherText);
+        bfCipherText.flip();
+        bfCipherText.get(encOutput);
+        Assert.assertArrayEquals(cipherText, encOutput);
+        c.close();
 
-            bfCipherText.flip();
-            bfCipherText.get(encOutput);
-            Assert.assertArrayEquals(cipherText, encOutput);
-            c.close();
-
-            // Decryption -------------------
-            CryptoCipher dec = Utils.getCipherInstance(transformation, props);
-            dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, "AES"),
-                    new GCMParameterSpec(128, ivBytes));
-            bfAAD.flip();
-            dec.updateAAD(bfAAD);
-            bfCipherText.clear();
-            bfPlainText.clear();
-            bfCipherText.put(cipherText);
-            bfCipherText.flip();
-            dec.doFinal(bfCipherText, bfPlainText);
-            bfPlainText.flip();
-            bfPlainText.get(decOutput);
-            Assert.assertArrayEquals(plainText, decOutput);
-            dec.close();
-        }
-        catch (Exception ex) {
-            Assert.fail(ex.getMessage());
-        }
+        // Decryption -------------------
+        CryptoCipher dec = Utils.getCipherInstance(transformation, props);
+        dec.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, "AES"),
+                new GCMParameterSpec(128, ivBytes));
+        bfAAD.flip();
+        dec.updateAAD(bfAAD);
+        bfCipherText.clear();
+        bfPlainText.clear();
+        bfCipherText.put(cipherText);
+        bfCipherText.flip();
+        dec.doFinal(bfCipherText, bfPlainText);
+        bfPlainText.flip();
+        bfPlainText.get(decOutput);
+        Assert.assertArrayEquals(plainText, decOutput);
+        dec.close();
     }
 
     private void initTestData() {

--- a/src/test/java/org/apache/commons/crypto/cipher/OpenSslCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/OpenSslCipherTest.java
@@ -42,45 +42,16 @@ public class OpenSslCipherTest extends AbstractCipherTest {
         cipherClass = OPENSSL_CIPHER_CLASSNAME;
     }
 
-    @Test(expected = NoSuchAlgorithmException.class, timeout = 120000)
-    public void testInvalidAlgorithm() throws Exception {
-        Assume.assumeTrue(OpenSsl.getLoadingFailureReason() == null);
-
-        try {
-            OpenSsl.getInstance("AES2/CTR/NoPadding");
-            Assert.fail("Should specify correct algorithm.");
-        } catch (NoSuchAlgorithmException e) {
-            Assert.assertTrue(e.getMessage().contains(
-                    "Doesn't support algorithm: AES2 and mode: CTR"));
-            throw e;
-        }
-    }
-
     @Test(expected = NoSuchPaddingException.class, timeout = 120000)
     public void testInvalidPadding() throws Exception {
         Assume.assumeTrue(OpenSsl.getLoadingFailureReason() == null);
-
-        try {
-            OpenSsl.getInstance("AES/CTR/NoPadding2");
-            Assert.fail("Should specify correct padding.");
-        } catch (NoSuchPaddingException e) {
-            Assert.assertTrue(e.getMessage().contains(
-                    "Doesn't support padding: NoPadding2"));
-            throw e;
-        }
+        OpenSsl.getInstance("AES/CTR/NoPadding2");
     }
 
     @Test(expected = NoSuchAlgorithmException.class, timeout = 120000)
     public void testInvalidMode() throws Exception {
         Assume.assumeTrue(OpenSsl.getLoadingFailureReason() == null);
-        try {
-            OpenSsl.getInstance("AES/CTR2/NoPadding");
-            Assert.fail("java.security.NoSuchAlgorithmException should be thrown.");
-        } catch (NoSuchAlgorithmException e) {
-            Assert.assertTrue(e.getMessage().contains(
-                    "Doesn't support algorithm: AES and mode: CTR2"));
-            throw e;
-        }
+        OpenSsl.getInstance("AES/CTR2/NoPadding");
     }
 
     @Test(timeout = 120000)
@@ -98,7 +69,7 @@ public class OpenSslCipherTest extends AbstractCipherTest {
 
         try {
             cipher.update(input, output);
-            Assert.fail("Input and output buffer should be direct buffer.");
+            Assert.fail("Should have failed to accept non-direct buffers.");
         } catch (IllegalArgumentException e) {
             Assert.assertTrue(e.getMessage().contains(
                     "Direct buffers are required"));
@@ -109,8 +80,7 @@ public class OpenSslCipherTest extends AbstractCipherTest {
         output = ByteBuffer.allocateDirect(1000);
         try {
             cipher.update(input, output);
-            Assert.fail("Output buffer length should be sufficient "
-                    + "to store output data");
+            Assert.fail("Failed to check for output buffer size.");
         } catch (ShortBufferException e) {
             Assert.assertTrue(e.getMessage().contains(
                     "Output buffer is not sufficient"));
@@ -132,7 +102,7 @@ public class OpenSslCipherTest extends AbstractCipherTest {
 
         try {
             cipher.doFinal(input, output);
-            Assert.fail("Output buffer should be direct buffer.");
+            Assert.fail("Should have failed to accept non-direct buffers.");
         } catch (IllegalArgumentException e) {
             Assert.assertTrue(e.getMessage().contains(
                     "Direct buffer is required"));
@@ -148,13 +118,7 @@ public class OpenSslCipherTest extends AbstractCipherTest {
 
         final byte[] invalidKey = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
                 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x11 };
-        try {
-            cipher.init(OpenSsl.ENCRYPT_MODE, invalidKey, new IvParameterSpec(IV));
-            Assert.fail("java.security.InvalidKeyException should be thrown.");
-        } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Invalid AES key length: " + invalidKey.length + " bytes"));
-            throw e;
-        }
+        cipher.init(OpenSsl.ENCRYPT_MODE, invalidKey, new IvParameterSpec(IV));
     }
 
     @Test(expected = InvalidAlgorithmParameterException.class, timeout = 120000)
@@ -166,13 +130,7 @@ public class OpenSslCipherTest extends AbstractCipherTest {
 
         final byte[] invalidIV = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
                 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x11 };
-        try {
-            cipher.init(OpenSsl.ENCRYPT_MODE, KEY, new IvParameterSpec(invalidIV));
-            Assert.fail("java.security.InvalidAlgorithmParameterException should be thrown.");
-        } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Wrong IV length: must be 16 bytes long"));
-            throw e;
-        }
+        cipher.init(OpenSsl.ENCRYPT_MODE, KEY, new IvParameterSpec(invalidIV));
     }
 
 }

--- a/src/test/java/org/apache/commons/crypto/jna/OpenSslJnaCryptoRandomTest.java
+++ b/src/test/java/org/apache/commons/crypto/jna/OpenSslJnaCryptoRandomTest.java
@@ -27,7 +27,7 @@ import org.apache.commons.crypto.random.CryptoRandomFactory;
 import org.junit.Assume;
 import org.junit.Before;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
 public class OpenSslJnaCryptoRandomTest extends AbstractRandomTest {
 
@@ -43,10 +43,9 @@ public class OpenSslJnaCryptoRandomTest extends AbstractRandomTest {
                 CryptoRandomFactory.CLASSES_KEY,
                 OpenSslJnaCryptoRandom.class.getName());
         CryptoRandom random = CryptoRandomFactory.getCryptoRandom(props);
-        if (!(random instanceof OpenSslJnaCryptoRandom)) {
-            fail("The CryptoRandom should be: "
-                    + OpenSslJnaCryptoRandom.class.getName());
-        }
+        assertTrue(
+                "The CryptoRandom should be: " + OpenSslJnaCryptoRandom.class.getName(),
+                random instanceof OpenSslJnaCryptoRandom);
         return random;
     }
 

--- a/src/test/java/org/apache/commons/crypto/random/JavaCryptoRandomTest.java
+++ b/src/test/java/org/apache/commons/crypto/random/JavaCryptoRandomTest.java
@@ -20,7 +20,7 @@ package org.apache.commons.crypto.random;
 import java.security.GeneralSecurityException;
 import java.util.Properties;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
 public class JavaCryptoRandomTest extends AbstractRandomTest {
 
@@ -31,10 +31,9 @@ public class JavaCryptoRandomTest extends AbstractRandomTest {
                 CryptoRandomFactory.CLASSES_KEY,
                 JavaCryptoRandom.class.getName());
         CryptoRandom random = CryptoRandomFactory.getCryptoRandom(props);
-        if (!(random instanceof JavaCryptoRandom)) {
-            fail("The CryptoRandom should be: "
-                    + JavaCryptoRandom.class.getName());
-        }
+        assertTrue(
+                "The CryptoRandom should be: " + JavaCryptoRandom.class.getName(),
+                random instanceof JavaCryptoRandom);
         return random;
     }
 

--- a/src/test/java/org/apache/commons/crypto/random/OpenSslCryptoRandomTest.java
+++ b/src/test/java/org/apache/commons/crypto/random/OpenSslCryptoRandomTest.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 import org.apache.commons.crypto.Crypto;
 import org.junit.Assume;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
 public class OpenSslCryptoRandomTest extends AbstractRandomTest {
 
@@ -35,10 +35,9 @@ public class OpenSslCryptoRandomTest extends AbstractRandomTest {
                 CryptoRandomFactory.CLASSES_KEY,
                 OpenSslCryptoRandom.class.getName());
         CryptoRandom random = CryptoRandomFactory.getCryptoRandom(props);
-        if (!(random instanceof OpenSslCryptoRandom)) {
-            fail("The CryptoRandom should be: "
-                    + OpenSslCryptoRandom.class.getName());
-        }
+        assertTrue(
+                "The CryptoRandom should be: " + OpenSslCryptoRandom.class.getName(),
+                random instanceof OpenSslCryptoRandom);
         return random;
     }
 

--- a/src/test/java/org/apache/commons/crypto/random/OsCryptoRandomTest.java
+++ b/src/test/java/org/apache/commons/crypto/random/OsCryptoRandomTest.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class OsCryptoRandomTest extends AbstractRandomTest {
@@ -38,15 +39,14 @@ public class OsCryptoRandomTest extends AbstractRandomTest {
                 CryptoRandomFactory.CLASSES_KEY,
                 OsCryptoRandom.class.getName());
         CryptoRandom random = CryptoRandomFactory.getCryptoRandom(props);
-        if (!(random instanceof OsCryptoRandom)) {
-            fail("The CryptoRandom should be: "
-                    + OsCryptoRandom.class.getName());
-        }
+        assertTrue(
+                "The CryptoRandom should be: " + OsCryptoRandom.class.getName(),
+                random instanceof OsCryptoRandom);
         return random;
     }
 
     @Test
-    public void testInvalidRansom() {
+    public void testInvalidRandom() {
         Properties props = new Properties();
         props.setProperty(CryptoRandomFactory.CLASSES_KEY, OsCryptoRandom.class.getName());
         // Invalid device

--- a/src/test/java/org/apache/commons/crypto/stream/PositionedCryptoInputStreamTest.java
+++ b/src/test/java/org/apache/commons/crypto/stream/PositionedCryptoInputStreamTest.java
@@ -268,7 +268,7 @@ public class PositionedCryptoInputStreamTest {
         byte[] bytes = new byte[length];
         try {
             in.readFully(position, bytes, 0, length);
-            Assert.fail("Excepted EOFException.");
+            Assert.fail("Expected IOException.");
         } catch (IOException ioe) {
             // excepted exception
         }


### PR DESCRIPTION
Catching exceptions and calling "Asserts.fail()" not only makes
the code more complicated than it should be, but it hides information
about the problem, since the original exception's stack trace is
lost.

It's also unnecessary to catch exceptions and fail the test when the
test itself declares that it's expecting that exception to be thrown.

While there I fixed a few misleading messages and some typos.