### PR TITLE
Add clirr:check target to CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - jdk_switcher use oraclejdk7
   - mvn verify site
   - jdk_switcher use oraclejdk8
-  - mvn verify site
+  - mvn verify clirr:check site
 
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ language: java
 matrix:
   include:
   - name: "Java 7"
-    jdk: oraclejdk7
+    jdk: openjdk7
   - name: "Java 8"
     jdk: oraclejdk8
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,20 +16,20 @@
 #
 language: java
 
-jdk:
-  - oraclejdk7
-  - oraclejdk8
+matrix:
+  include:
+  - name: "Java 7"
+    jdk: oraclejdk7
+  - name: "Java 8"
+    jdk: oraclejdk8
 
 before_install:
   - "curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip && sudo unzip -j -o /tmp/policy.zip *.jar -d `jdk_switcher home oraclejdk8`/jre/lib/security && rm /tmp/policy.zip"
 
 script:
   - mvn apache-rat:check
-  - mvn clean test package
-  - jdk_switcher use oraclejdk7
-  - mvn verify site
-  - jdk_switcher use oraclejdk8
-  - mvn verify clirr:check site
+  - mvn site
+  - mvn clirr:check
 
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,11 @@
 #
 language: java
 
-matrix:
-  include:
-  - name: "Java 7"
-    jdk: openjdk7
-  - name: "Java 8"
-    jdk: oraclejdk8
-    before_install:
-      - "curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip && sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security && rm /tmp/policy.zip"
+jdk:
+  - oraclejdk8
+
+before_install:
+  - "curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip && sudo unzip -j -o /tmp/policy.zip *.jar -d `jdk_switcher home oraclejdk8`/jre/lib/security && rm /tmp/policy.zip"
 
 script:
   - mvn apache-rat:check

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ matrix:
     jdk: oraclejdk7
   - name: "Java 8"
     jdk: oraclejdk8
-
-before_install:
-  - "curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip && sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security && rm /tmp/policy.zip"
+    before_install:
+      - "curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip && sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security && rm /tmp/policy.zip"
 
 script:
   - mvn apache-rat:check

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     jdk: oraclejdk8
 
 before_install:
-  - "curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip && sudo unzip -j -o /tmp/policy.zip *.jar -d `jdk_switcher home oraclejdk8`/jre/lib/security && rm /tmp/policy.zip"
+  - "curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip && sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security && rm /tmp/policy.zip"
 
 script:
   - mvn apache-rat:check

--- a/clirr-excludes.xml
+++ b/clirr-excludes.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
 <differences>
   <difference>
     <!--

--- a/clirr-excludes.xml
+++ b/clirr-excludes.xml
@@ -16,8 +16,8 @@
 <differences>
   <difference>
     <!--
-      Ignore added methods to CryptoCipher interface. All implementations are expected to be within
-      commons-crypto itself.
+      Ignore added methods to CryptoCipher interface. clirr does not detect default methods
+      introduced in Java 8.
     -->
     <className>org/apache/commons/crypto/cipher/CryptoCipher</className>
     <differenceType>7012</differenceType>

--- a/clirr-excludes.xml
+++ b/clirr-excludes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<differences>
+  <difference>
+    <!--
+      Ignore added methods to CryptoCipher interface. All implementations are expected to be within
+      commons-crypto itself.
+    -->
+    <className>org/apache/commons/crypto/cipher/CryptoCipher</className>
+    <differenceType>7012</differenceType>
+    <method>*</method>
+  </difference>
+</differences>

--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,13 @@ The following provides more details on the included cryptographic software:
             <artifactId>coveralls-maven-plugin</artifactId>
             <version>3.1.0</version>
           </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>clirr-maven-plugin</artifactId>
+            <configuration>
+              <ignoredDifferencesFile>${basedir}/clirr-excludes.xml</ignoredDifferencesFile>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
       <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>43</version>
+    <version>47</version>
   </parent>
 
   <groupId>org.apache.commons</groupId>
@@ -641,6 +641,13 @@ The following provides more details on the included cryptographic software:
             <exclude>.idea/**</exclude>
             <exclude>**/build/**</exclude>
           </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>javancss-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/apache/commons/crypto/cipher/CryptoCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/CryptoCipher.java
@@ -34,7 +34,7 @@ import javax.crypto.ShortBufferException;
  * Note that implementations must provide a constructor that has 2 parameters:
  * <br>
  * a Properties instance and a String (transformation)
- * 
+ *
  */
 public interface CryptoCipher extends Closeable {
 
@@ -60,7 +60,7 @@ public interface CryptoCipher extends Closeable {
     /**
      * Initializes the cipher with mode, key and iv.
      *
-     * @param mode {@link javax.crypto.Cipher#ENCRYPT_MODE} or 
+     * @param mode {@link javax.crypto.Cipher#ENCRYPT_MODE} or
      *             {@link javax.crypto.Cipher#DECRYPT_MODE}
      * @param key crypto key for the cipher
      * @param params the algorithm parameters
@@ -177,8 +177,10 @@ public interface CryptoCipher extends Closeable {
      * has not been overridden by an implementation
      *
      */
-    void updateAAD(byte[] aad)
-            throws IllegalArgumentException, IllegalStateException, UnsupportedOperationException;
+    default void updateAAD(byte[] aad)
+            throws IllegalArgumentException, IllegalStateException, UnsupportedOperationException {
+      throw new UnsupportedOperationException();
+    }
 
     /**
      * Continues a multi-part update of the Additional Authentication
@@ -203,6 +205,8 @@ public interface CryptoCipher extends Closeable {
      * has not been overridden by an implementation
      *
      */
-    void updateAAD(ByteBuffer aad)
-            throws IllegalArgumentException, IllegalStateException, UnsupportedOperationException;
+    default void updateAAD(ByteBuffer aad)
+            throws IllegalArgumentException, IllegalStateException, UnsupportedOperationException {
+      throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
- add default implementations for new interface methods that were added 
- add an excludes file with an entry to ignore the current clirr failure
- disable javancss plugin since it does not like java 8 default methods