### PR TITLE
Revert to commons-parent v43.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>47</version>
+    <version>43</version>
   </parent>
 
   <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Seems like the newer maven-enforcer-plugin version is either buggy
or does not like maven 3.0 (since it seems to work fine with 3.5
locally). Let's revert to the previous commons-parent version for
now (which sets the enforcer plugin to version 1.4.1).