### PR TITLE
Clean up a few build warnings.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -38,6 +38,7 @@ limitations under the License.
     <module name="NeedBraces"/>
     <module name="JavadocMethod">
       <property name="allowUndeclaredRTE" value="true"/>
+      <property name="scope" value="protected"/>
     </module>
  </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -560,6 +560,7 @@ The following provides more details on the included cryptographic software:
         <configuration>
           <configLocation>${basedir}/checkstyle.xml</configLocation>
           <enableRulesSummary>false</enableRulesSummary>
+          <failsOnError>true</failsOnError>
         </configuration>
         <reportSets>
           <reportSet>
@@ -632,11 +633,6 @@ The following provides more details on the included cryptographic software:
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>javancss-maven-plugin</artifactId>
-        <version>2.1</version>
-      </plugin>
-      <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
@@ -647,13 +643,6 @@ The following provides more details on the included cryptographic software:
             <exclude>.idea/**</exclude>
             <exclude>**/build/**</exclude>
           </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>javancss-maven-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslCipher.java
@@ -28,7 +28,6 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.ShortBufferException;
-import javax.crypto.spec.IvParameterSpec;
 
 import org.apache.commons.crypto.utils.Utils;
 

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslCommonMode.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslCommonMode.java
@@ -32,7 +32,7 @@ import java.security.spec.AlgorithmParameterSpec;
  */
 class OpenSslCommonMode extends OpenSslFeedbackCipher {
 
-    public OpenSslCommonMode(long context, int algorithmMode, int padding) {
+    OpenSslCommonMode(long context, int algorithmMode, int padding) {
         super(context, algorithmMode, padding);
     }
 

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslEvpCtrlValues.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslEvpCtrlValues.java
@@ -46,7 +46,7 @@ enum OpenSslEvpCtrlValues {
         this.value = value;
     }
 
-    public int getValue() {
+    int getValue() {
         return value;
     }
 }


### PR DESCRIPTION
- remove references to the javancss plugin
- clear up javadoc warnings from checkstyle by only requiring them for
  methods that are protected (or more visible)
- remove an unused import