### PR TITLE
CRYPTO-135: Add comment about need for blocking sinks.

### DIFF
--- a/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
@@ -43,6 +43,10 @@ import org.apache.commons.crypto.utils.Utils;
  * {@link CryptoOutputStream} encrypts data and writes to the under layer
  * output. It supports any mode of operations such as AES CBC/CTR/GCM mode in
  * concept. It is not thread-safe.
+ * <p>
+ * This class should only be used with blocking sinks. Using this class to wrap
+ * a non-blocking sink may lead to high CPU usage.
+ * </p>
  */
 
 public class CryptoOutputStream extends OutputStream implements

--- a/src/main/java/org/apache/commons/crypto/stream/CtrCryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CtrCryptoOutputStream.java
@@ -48,7 +48,13 @@ import org.apache.commons.crypto.utils.Utils;
  * counter = base + pos/(algorithm blocksize); padding = pos%(algorithm
  * blocksize);
  * </p>
+ * <p>
  * The underlying stream offset is maintained as state.
+ * </p>
+ * <p>
+ * This class should only be used with blocking sinks. Using this class to wrap
+ * a non-blocking sink may lead to high CPU usage.
+ * </p>
  */
 public class CtrCryptoOutputStream extends CryptoOutputStream {
     /**


### PR DESCRIPTION
Implementing non-blocking semantics in the WritableByteChannel portion
of CryptoOutputStream is non-trivial. The existing options require weird
return values and thus require the caller to know they're writing to
a CryptoOutputStream and not a regular byte channel. In that case, it's
better for the app to just not use the stream implementation and use
the ciphers directly, since that gives the code better control of
encryption.

This change just adds comments to warn API users that the output
streams are expected to be used only with blocking I/O.

Closes #74