### PR TITLE
JNA version is updated to 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ The following provides more details on the included cryptographic software:
     <commons.release.version>1.0.0</commons.release.version>
     <commons.release.desc>(Requires Java ${maven.compiler.target} or later)</commons.release.desc>
     <commons.rc.version>RC1</commons.rc.version>
-    <jna.version>4.2.2</jna.version>
+    <jna.version>4.4.0</jna.version>
 
     <!-- properties not related to versioning -->
     <commons.jira.id>CRYPTO</commons.jira.id>


### PR DESCRIPTION
jvm is getting crashed on AARCH64 platform
(CentOS7) with openJDK8 with JNA version 4.2.2
and working fine with JNA 4.4.0