### PR TITLE
Update pom.xml to explicitly prevent cleaning during release:prepare

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -606,6 +606,14 @@ The following provides more details on the included cryptographic software:
           <ignoredDifferencesFile>${basedir}/clirr-excludes.xml</ignoredDifferencesFile>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <preparationGoals>verify</preparationGoals>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <reporting>


### PR DESCRIPTION
Update pom.xml to configure the maven-release-plugin to not perform and clean when doing a release:prepare to allow build artifacts from other platform builds to be incorporated into the final Jar for publishing to the maven artifact repositories.