### PR TITLE
Add support for Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,14 @@ before_install:
     curl -L --cookie 'oraclelicense=accept-securebackup-cookie;' http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
-  - brew install openssl
-  - ls -la /usr/local/Cellar/openssl
+  - brew upgrade
+  - brew install openssl@1.1
+  - ls -la /usr/local/Cellar/
+  - cd /usr/local/Cellar/openssl@1.1/1.1.1d/lib
+  - sudo cp libssl.1.1.dylib libcrypto.1.1.dylib /usr/local/lib/
+  - cd /usr/local/lib
+  - sudo ln -s libssl.1.1.dylib libssl.dylib
+  - sudo ln -s libcrypto.1.1.dylib libcrypto.dylib
   - openssl version -a
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ before_install:
   - ls -la /usr/local/opt/openssl@1.1/lib
   - ls -la /usr/lib
   - ls -la /usr/local/lib
-  - sudo cp /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib /usr/lib/
+  - rm -f /usr/lib/libcrypto.dylib
+  - sudo ln -s /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib /usr/lib/libcrypto.dylib
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V
 after_success: mvn site -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,12 @@ before_install:
     curl -L --cookie 'oraclelicense=accept-securebackup-cookie;' http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
-  - brew update
   - brew install openssl@1.1 --force
   - export PATH="/usr/local/opt/openssl@1.1/bin:$PATH" >> ~/.bash_profile
   - export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
   - export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+  - export LD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib:$LD_LIBRARY_PATH"
+  - export DYLD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib:$DYLD_LIBRARY_PATH"
   - openssl version -a
   - ls -la /usr/local/lib
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
   - ls -la /usr/local/opt/openssl@1.1/lib
   - ls -la /usr/lib
   - ls -la /usr/local/lib
-  - rm -f /usr/lib/libcrypto.dylib
+  - sudo rm -f /usr/lib/libcrypto.dylib
   - sudo ln -s /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib /usr/lib/libcrypto.dylib
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ before_install:
     curl -L --cookie 'oraclelicense=accept-securebackup-cookie;' http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
-  - brew uninstall libressl
   - brew install openssl
+  - ls -la /usr/local/Cellar/openssl
   - openssl version -a
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
       dist: xenial
       jdk: openjdk11
       env:
-        - JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-arm64
+        - JAVA_HOME=/usr/lib/jvm/adoptopenjdk-11-hotspot-arm64
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ before_install:
   - export LD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib:$LD_LIBRARY_PATH"
   - export DYLD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib:$DYLD_LIBRARY_PATH"
   - openssl version -a
-  - ls -la /usr/local/lib
+  - ls -la /usr/local/etc/openssl@1.1
+  - ls -la /usr/local/opt/openssl@1.1/lib
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V
 after_success: mvn site -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ before_install:
   - openssl version -a
   - ls -la /usr/local/etc/openssl@1.1
   - ls -la /usr/local/opt/openssl@1.1/lib
+  - ls -la /usr/lib
+  - ls -la /usr/local/lib
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V
 after_success: mvn site -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_install:
   - ls -la /usr/local/opt/openssl@1.1/lib
   - ls -la /usr/lib
   - ls -la /usr/local/lib
+  - sudo cp /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib /usr/lib/
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V
 after_success: mvn site -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,70 +19,10 @@ language: java
 matrix:
   include:
 
-    - name: "x64 / Ubuntu 14.04 / Java 8 / OpenSSL 1.0.x"
-      arch: amd64
-      os: linux
-      dist: trusty
-      jdk: openjdk8
-
-    - name: "x64 / Ubuntu 18.04 / Java 8 / OpenSSL 1.1.x"
-      arch: amd64
-      os: linux
-      dist: bionic
-      jdk: openjdk8
-
-    - name: "aarch64 / Ubuntu 16.04 / Java 8 / OpenSSL 1.0.x"
-      arch: arm64
-      os: linux
-      dist: xenial
-      jdk: openjdk8
-      env:
-        - JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-arm64
-      addons:
-        apt:
-          packages:
-            - maven
-
-    - name: "aarch64 / Ubuntu 18.04 / Java 8 / OpenSSL 1.1.x"
-      arch: arm64
-      os: linux
-      dist: bionic
-      jdk: openjdk8
-      env:
-        - JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-arm64
-      addons:
-        apt:
-          packages:
-            - maven
-
-    - name: "ppc64le / Ubuntu 16.04 / Java 8 / OpenSSL 1.0.x"
-      arch: ppc64le
-      os: linux
-      dist: xenial
-      jdk: openjdk8
-      env:
-        - JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-ppc64el
-      addons:
-        apt:
-          packages:
-            - maven
-
-    - name: "ppc64le / Ubuntu 18.04 / Java 8 / OpenSSL 1.1.x"
-      arch: ppc64le
-      os: linux
-      dist: bionic
-      jdk: openjdk8
-      env:
-        - JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-ppc64el
-      addons:
-        apt:
-          packages:
-            - maven
-
-    - name: "OS X / Java 8 / LibreSSL 2.2.x"
+    - name: "OS X / Java 11 / OpenSSL 1.1.x"
       os: osx
       osx_image: xcode9.3
-      jdk: oraclejdk8
+      jdk: oraclejdk11
       env:
         - JAVA_HOME=$(/usr/libexec/java_home)
 
@@ -91,6 +31,7 @@ before_install:
     curl -L --cookie 'oraclelicense=accept-securebackup-cookie;' http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
+  - brew install openssl
   - openssl version -a
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
   - ls -la /usr/local/opt/openssl@1.1/lib
   - ls -la /usr/lib
   - ls -la /usr/local/lib
-  - sudo rm -f /usr/lib/libcrypto.dylib
+  - sudo mv /usr/lib/libcrypto.dylib /usr/lib/libcrypto.bak.dylib
   - sudo ln -s /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib /usr/lib/libcrypto.dylib
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
   - brew update
-  - brew install openssl@1.1
+  - brew install openssl@1.1 --force
   - cd /usr/local/Cellar/openssl@1.1/1.1.1g/lib
   - sudo cp libssl.1.1.dylib libcrypto.1.1.dylib /usr/local/lib/
   - cd /usr/local/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,7 @@ before_install:
     rm /tmp/policy.zip
   - brew upgrade
   - brew install openssl@1.1
-<<<<<<< HEAD
   - ls -la /usr/local/Cellar/
-=======
-    - ls -la /usr/local/Cellar/
->>>>>>> branch 'jdkgt8' of https://github.com/aremily/commons-crypto.git
   - cd /usr/local/Cellar/openssl@1.1/1.1.1d/lib
   - sudo cp libssl.1.1.dylib libcrypto.1.1.dylib /usr/local/lib/
   - cd /usr/local/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ before_install:
     curl -L --cookie 'oraclelicense=accept-securebackup-cookie;' http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
-  - brew upgrade openssl@1.1
+  - brew update
+  - brew install openssl@1.1
   - cd /usr/local/Cellar/openssl@1.1/1.1.1g/lib
   - sudo cp libssl.1.1.dylib libcrypto.1.1.dylib /usr/local/lib/
   - cd /usr/local/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
   - export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
   - export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
   - openssl version -a
+  - ls -la /usr/local/lib
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V
 after_success: mvn site -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,9 @@ before_install:
     rm /tmp/policy.zip
   - brew update
   - brew install openssl@1.1 --force
-  - cd /usr/local/Cellar/openssl@1.1/1.1.1g/lib
-  - sudo cp libssl.1.1.dylib libcrypto.1.1.dylib /usr/local/lib/
-  - cd /usr/local/lib
-  - sudo ln -s libssl.1.1.dylib libssl.dylib
-  - sudo ln -s libcrypto.1.1.dylib libcrypto.dylib
+  - export PATH="/usr/local/opt/openssl@1.1/bin:$PATH" >> ~/.bash_profile
+  - export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+  - export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
   - openssl version -a
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+  
 #
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
@@ -19,10 +20,70 @@ language: java
 matrix:
   include:
 
-    - name: "OS X / Java 11 / OpenSSL 1.1.x"
+    - name: "x64 / Ubuntu 14.04 / Java 11 / OpenSSL 1.0.x"
+      arch: amd64
+      os: linux
+      dist: trusty
+      jdk: openjdk11
+
+    - name: "x64 / Ubuntu 18.04 / Java 11 / OpenSSL 1.1.x"
+      arch: amd64
+      os: linux
+      dist: bionic
+      jdk: openjdk11
+
+    - name: "aarch64 / Ubuntu 16.04 / Java 11 / OpenSSL 1.0.x"
+      arch: arm64
+      os: linux
+      dist: xenial
+      jdk: openjdk11
+      env:
+        - JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-arm64
+      addons:
+        apt:
+          packages:
+            - maven
+
+    - name: "aarch64 / Ubuntu 18.04 / Java 8 / OpenSSL 1.1.x"
+      arch: arm64
+      os: linux
+      dist: bionic
+      jdk: openjdk8
+      env:
+        - JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-arm64
+      addons:
+        apt:
+          packages:
+            - maven
+
+    - name: "ppc64le / Ubuntu 16.04 / Java 8 / OpenSSL 1.0.x"
+      arch: ppc64le
+      os: linux
+      dist: xenial
+      jdk: openjdk8
+      env:
+        - JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-ppc64el
+      addons:
+        apt:
+          packages:
+            - maven
+
+    - name: "ppc64le / Ubuntu 18.04 / Java 8 / OpenSSL 1.1.x"
+      arch: ppc64le
+      os: linux
+      dist: bionic
+      jdk: openjdk8
+      env:
+        - JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-ppc64el
+      addons:
+        apt:
+          packages:
+            - maven
+
+    - name: "OS X / Java 8 / LibreSSL 2.2.x"
       os: osx
       osx_image: xcode9.3
-      jdk: oraclejdk11
+      jdk: oraclejdk8
       env:
         - JAVA_HOME=$(/usr/libexec/java_home)
 
@@ -31,19 +92,7 @@ before_install:
     curl -L --cookie 'oraclelicense=accept-securebackup-cookie;' http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
-  - brew install openssl@1.1 --force
-  - export PATH="/usr/local/opt/openssl@1.1/bin:$PATH" >> ~/.bash_profile
-  - export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
-  - export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
-  - export LD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib:$LD_LIBRARY_PATH"
-  - export DYLD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib:$DYLD_LIBRARY_PATH"
   - openssl version -a
-  - ls -la /usr/local/etc/openssl@1.1
-  - ls -la /usr/local/opt/openssl@1.1/lib
-  - ls -la /usr/lib
-  - ls -la /usr/local/lib
-  - sudo mv /usr/lib/libcrypto.dylib /usr/lib/libcrypto.bak.dylib
-  - sudo ln -s /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib /usr/lib/libcrypto.dylib
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test jacoco:report coveralls:report -B -V
 after_success: mvn site -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,8 @@ before_install:
     curl -L --cookie 'oraclelicense=accept-securebackup-cookie;' http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
-  - brew upgrade
-  - brew install openssl@1.1
-  - ls -la /usr/local/Cellar/
-  - cd /usr/local/Cellar/openssl@1.1/1.1.1d/lib
+  - brew upgrade openssl@1.1
+  - cd /usr/local/Cellar/openssl@1.1/1.1.1g/lib
   - sudo cp libssl.1.1.dylib libcrypto.1.1.dylib /usr/local/lib/
   - cd /usr/local/lib
   - sudo ln -s libssl.1.1.dylib libssl.dylib

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
     curl -L --cookie 'oraclelicense=accept-securebackup-cookie;' http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/policy.zip
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
+  - brew uninstall libressl
   - brew install openssl
   - openssl version -a
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V

--- a/Makefile
+++ b/Makefile
@@ -37,15 +37,30 @@ NATIVE_DLL:=$(NATIVE_TARGET_DIR)/$(LIBNAME)
 
 all: $(NATIVE_DLL)
 
-$(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpenSslNative.h: $(TARGET)/classes/org/apache/commons/crypto/cipher/OpenSslNative.class
-	$(JAVAH) -force -classpath $(TARGET)/classes -o $@ org.apache.commons.crypto.cipher.OpenSslNative
+#JDK9 and later
+ifeq ($(GT_JDK8),true)
+  $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpenSslNative.h:
+	  javac -h $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/ -d $(TARGET)/classes src/main/java/org/apache/commons/crypto/cipher/OpenSslNative.java
+	  mv $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/org_apache_commons_crypto_cipher_OpenSslNative.h $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpenSslNative.h
 
-$(TARGET)/jni-classes/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.h: $(TARGET)/classes/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.class
-	$(JAVAH) -force -classpath $(TARGET)/classes -o $@ org.apache.commons.crypto.random.OpenSslCryptoRandomNative
+  $(TARGET)/jni-classes/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.h:
+	  javac -h $(TARGET)/jni-classes/org/apache/commons/crypto/random/ -d $(TARGET)/classes src/main/java/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.java 
+	  mv $(TARGET)/jni-classes/org/apache/commons/crypto/random/org_apache_commons_crypto_random_OpenSslCryptoRandomNative.h $(TARGET)/jni-classes/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.h
 
-$(TARGET)/jni-classes/org/apache/commons/crypto/OpenSslInfoNative.h: $(TARGET)/classes/org/apache/commons/crypto/OpenSslInfoNative.class
-	$(JAVAH) -force -classpath $(TARGET)/classes -o $@ org.apache.commons.crypto.OpenSslInfoNative
+  $(TARGET)/jni-classes/org/apache/commons/crypto/OpenSslInfoNative.h:
+	  javac -h $(TARGET)/jni-classes/org/apache/commons/crypto/ -d $(TARGET)/classes src/main/java/org/apache/commons/crypto/OpenSslInfoNative.java
+	  mv $(TARGET)/jni-classes/org/apache/commons/crypto/org_apache_commons_crypto_OpenSslInfoNative.h $(TARGET)/jni-classes/org/apache/commons/crypto/OpenSslInfoNative.h
+#JDK8 and before
+else
+  $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpenSslNative.h: $(TARGET)/classes/org/apache/commons/crypto/cipher/OpenSslNative.class
+	  $(JAVAH) -force -classpath $(TARGET)/classes -o $@ org.apache.commons.crypto.cipher.OpenSslNative
 
+  $(TARGET)/jni-classes/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.h: $(TARGET)/classes/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.class
+	  $(JAVAH) -force -classpath $(TARGET)/classes -o $@ org.apache.commons.crypto.random.OpenSslCryptoRandomNative
+
+  $(TARGET)/jni-classes/org/apache/commons/crypto/OpenSslInfoNative.h: $(TARGET)/classes/org/apache/commons/crypto/OpenSslInfoNative.class
+	  $(JAVAH) -force -classpath $(TARGET)/classes -o $@ org.apache.commons.crypto.OpenSslInfoNative
+endif
 $(COMMONS_CRYPTO_OUT)/OpenSslNative.o : $(SRC_NATIVE)/org/apache/commons/crypto/cipher/OpenSslNative.c $(TARGET)/jni-classes/org/apache/commons/crypto/cipher/OpenSslNative.h
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/Makefile.common
+++ b/Makefile.common
@@ -41,6 +41,8 @@ OSINFO_PROG := $(TARGET)/classes/org/apache/commons/crypto/OsInfo.class
 OS_NAME := $(shell $(JAVA) -cp $(TARGET)/classes $(OSINFO_CLASS) --os)
 OS_ARCH := $(shell $(JAVA) -cp $(TARGET)/classes $(OSINFO_CLASS) --arch)
 LIB_FOLDER := $(shell $(JAVA) -cp $(TARGET)/classes $(OSINFO_CLASS))
+JDK_VER := $(shell $(JAVA) -cp $(TARGET)/classes $(OSINFO_CLASS) --jdk)
+GT_JDK8 := $(shell [ $(JDK_VER) -gt 8 ] && echo true)
 
 commons-crypto := commons-crypto-$(VERSION)
 

--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,24 @@ The following provides more details on the included cryptographic software:
         </plugins>
       </build>
     </profile>
-
+    <profile>
+      <id>jdk11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <!-- Prevent Surefire from crashing VM when forking during native code execution. -->            
+            <configuration>
+              <reuseForks>false</reuseForks>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>
@@ -613,7 +630,6 @@ The following provides more details on the included cryptographic software:
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
         <configuration>
           <preparationGoals>verify</preparationGoals>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -430,9 +430,9 @@ The following provides more details on the included cryptographic software:
       </build>
     </profile>
     <profile>
-      <id>jdk11</id>
+      <id>jdkgte10</id>
       <activation>
-        <jdk>11</jdk>
+        <jdk>[10,)</jdk>
       </activation>
       <build>
         <plugins>

--- a/src/main/java/org/apache/commons/crypto/OpenSslInfoNative.java
+++ b/src/main/java/org/apache/commons/crypto/OpenSslInfoNative.java
@@ -17,8 +17,6 @@
  */
 package org.apache.commons.crypto;
 
-import org.apache.commons.crypto.random.CryptoRandom;
-
 /**
  * JNI interface of {@link CryptoRandom} implementation for OpenSSL.
  * The native method in this class is defined in

--- a/src/main/java/org/apache/commons/crypto/OsInfo.java
+++ b/src/main/java/org/apache/commons/crypto/OsInfo.java
@@ -20,6 +20,7 @@ package org.apache.commons.crypto;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.StringTokenizer;
 
 /**
  * Provides OS name and architecture name.
@@ -122,6 +123,9 @@ final class OsInfo {
             } else if ("--arch".equals(args[0])) {
                 System.out.print(getArchName());
                 return;
+            } else if ("--jdk".equals(args[0])) {
+                System.out.print(getJDKMajorVersionNumber());
+                return;
             }
         }
 
@@ -182,6 +186,18 @@ final class OsInfo {
             }
         }
         return translateArchNameToFolderName(osArch);
+    }
+    
+    static String getJDKMajorVersionNumber() {
+        return translateJDKStringToMajorVersionNumber(System.getProperty("java.version"));
+    }
+
+    private static String translateJDKStringToMajorVersionNumber(String jdkVersion) {
+        StringTokenizer tokens = new StringTokenizer(jdkVersion, ".");
+        String jdkMajorVersion = tokens.nextToken();
+        if(jdkMajorVersion.equals("1"))
+            jdkMajorVersion = tokens.nextToken();
+        return jdkMajorVersion;
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslCommonMode.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslCommonMode.java
@@ -17,6 +17,7 @@
  */
 package org.apache.commons.crypto.cipher;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.spec.AlgorithmParameterSpec;
@@ -58,8 +59,8 @@ class OpenSslCommonMode extends OpenSslFeedbackCipher {
         final int len = OpenSslNative.update(context, input, input.position(),
                 input.remaining(), output, output.position(),
                 output.remaining());
-        input.position(input.limit());
-        output.position(output.position() + len);
+        ((Buffer)input).position(input.limit());
+        ((Buffer)output).position(output.position() + len);
 
         return len;
     }
@@ -97,14 +98,14 @@ class OpenSslCommonMode extends OpenSslFeedbackCipher {
                 input.remaining(), output, output.position(), output.remaining());
         totalLen += len;
 
-        input.position(input.limit());
-        output.position(output.position() + len);
+        ((Buffer)input).position(input.limit());
+        ((Buffer)output).position(output.position() + len);
 
         len = OpenSslNative.doFinal(context, output, output.position(),
                 output.remaining());
         totalLen += len;
 
-        output.position(output.position() + len);
+        ((Buffer)output).position(output.position() + len);
 
         return totalLen;
     }

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslGaloisCounterMode.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslGaloisCounterMode.java
@@ -18,6 +18,7 @@
 package org.apache.commons.crypto.cipher;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.InvalidAlgorithmParameterException;
@@ -99,8 +100,8 @@ class OpenSslGaloisCounterMode extends OpenSslFeedbackCipher {
             len = OpenSslNative.update(context, input, input.position(),
                     input.remaining(), output, output.position(),
                     output.remaining());
-            input.position(input.limit());
-            output.position(output.position() + len);
+            ((Buffer)input).position(input.limit());
+            ((Buffer)output).position(output.position() + len);
         }
 
         return len;
@@ -160,7 +161,7 @@ class OpenSslGaloisCounterMode extends OpenSslFeedbackCipher {
             // set tag to EVP_Cipher for integrity verification in doFinal
             final ByteBuffer tag = ByteBuffer.allocate(getTagLen());
             tag.put(input, input.length - getTagLen(), getTagLen());
-            tag.flip();
+            ((Buffer)tag).flip();
             evpCipherCtxCtrl(context, OpenSslEvpCtrlValues.AEAD_SET_TAG.getValue(), getTagLen(), tag);
         } else {
             len = OpenSslNative.updateByteArray(context, input, inputOffset,
@@ -213,7 +214,7 @@ class OpenSslGaloisCounterMode extends OpenSslFeedbackCipher {
 
                 // retrieve tag
                 tag.put(inputFinal, inputFinal.length - getTagLen(), getTagLen());
-                tag.flip();
+                ((Buffer)tag).flip();
 
             } else {
                 // if no buffered input, just use the input directly
@@ -225,11 +226,11 @@ class OpenSslGaloisCounterMode extends OpenSslFeedbackCipher {
                         input.remaining() - getTagLen(), output, output.position(),
                         output.remaining());
 
-                input.position(input.position() + len);
+                ((Buffer)input).position(input.position() + len);
 
                 // retrieve tag
                 tag.put(input);
-                tag.flip();
+                ((Buffer)tag).flip();
             }
 
             // set tag to EVP_Cipher for integrity verification in doFinal
@@ -239,15 +240,15 @@ class OpenSslGaloisCounterMode extends OpenSslFeedbackCipher {
             len = OpenSslNative.update(context, input, input.position(),
                     input.remaining(), output, output.position(),
                     output.remaining());
-            input.position(input.limit());
+            ((Buffer)input).position(input.limit());
         }
 
         totalLen += len;
-        output.position(output.position() + len);
+        ((Buffer)output).position(output.position() + len);
 
         len = OpenSslNative.doFinal(context, output, output.position(),
                 output.remaining());
-        output.position(output.position() + len);
+        ((Buffer)output).position(output.position() + len);
         totalLen += len;
 
         // Keep the similar behavior as JCE, append the tag to end of output

--- a/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCipher.java
+++ b/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCipher.java
@@ -17,6 +17,7 @@
  */
 package org.apache.commons.crypto.jna;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
@@ -152,8 +153,8 @@ class OpenSslJnaCipher implements CryptoCipher {
         final int retVal = OpenSslNativeJna.EVP_CipherUpdate(context, outBuffer, outlen, inBuffer, inBuffer.remaining());
         throwOnError(retVal);
         final int len = outlen[0];
-        inBuffer.position(inBuffer.limit());
-        outBuffer.position(outBuffer.position() + len);
+        ((Buffer)inBuffer).position(inBuffer.limit());
+        ((Buffer)outBuffer).position(outBuffer.position() + len);
         return len;
     }
 
@@ -205,7 +206,7 @@ class OpenSslJnaCipher implements CryptoCipher {
         final int retVal = OpenSslNativeJna.EVP_CipherFinal_ex(context, outBuffer, outlen);
         throwOnError(retVal);
         final int len = uptLen + outlen[0];
-        outBuffer.position(outBuffer.position() + outlen[0]);
+        ((Buffer)outBuffer).position(outBuffer.position() + outlen[0]);
         return len;
     }
 

--- a/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCryptoRandom.java
@@ -17,6 +17,7 @@
  */
 package org.apache.commons.crypto.jna;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
@@ -110,7 +111,7 @@ class OpenSslJnaCryptoRandom extends Random implements CryptoRandom {
             final ByteBuffer buf = ByteBuffer.allocateDirect(bytes.length);
             final int retVal = OpenSslNativeJna.RAND_bytes(buf, bytes.length);
             throwOnError(retVal);
-            buf.rewind();
+            ((Buffer)buf).rewind();
             buf.get(bytes,0, bytes.length);
         }
     }

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
@@ -20,6 +20,7 @@ package org.apache.commons.crypto.stream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.security.InvalidAlgorithmParameterException;
@@ -203,7 +204,7 @@ public class CryptoInputStream extends InputStream implements
         inBuffer = ByteBuffer.allocateDirect(this.bufferSize);
         outBuffer = ByteBuffer.allocateDirect(this.bufferSize
                 + cipher.getBlockSize());
-        outBuffer.limit(0);
+        ((Buffer)outBuffer).limit(0);
 
         initCipher();
     }
@@ -293,14 +294,14 @@ public class CryptoInputStream extends InputStream implements
         while (remaining > 0) {
             if (remaining <= outBuffer.remaining()) {
                 // Skip in the remaining buffer
-                final int pos = outBuffer.position() + (int) remaining;
-                outBuffer.position(pos);
+                final int pos = ((Buffer)outBuffer).position() + (int) remaining;
+                ((Buffer)outBuffer).position(pos);
 
                 remaining = 0;
                 break;
             }
-            remaining -= outBuffer.remaining();
-            outBuffer.clear();
+            remaining -= ((Buffer)outBuffer).remaining();
+            ((Buffer)outBuffer).clear();
 
             // we loop for new data
             nd = 0;
@@ -426,10 +427,10 @@ public class CryptoInputStream extends InputStream implements
         remaining = outBuffer.remaining();
         final int toRead = dst.remaining();
         if (toRead <= remaining) {
-            final int limit = outBuffer.limit();
-            outBuffer.limit(outBuffer.position() + toRead);
+            final int limit = ((Buffer)outBuffer).limit();
+            ((Buffer)outBuffer).limit(((Buffer)outBuffer).position() + toRead);
             dst.put(outBuffer);
-            outBuffer.limit(limit);
+            ((Buffer)outBuffer).limit(limit);
             return toRead;
         }
         dst.put(outBuffer);
@@ -542,8 +543,8 @@ public class CryptoInputStream extends InputStream implements
      */
     protected void decrypt() throws IOException {
         // Prepare the input buffer and clear the out buffer
-        inBuffer.flip();
-        outBuffer.clear();
+        ((Buffer)inBuffer).flip();
+        ((Buffer)outBuffer).clear();
 
         try {
             cipher.update(inBuffer, outBuffer);
@@ -552,8 +553,8 @@ public class CryptoInputStream extends InputStream implements
         }
 
         // Clear the input buffer and prepare out buffer
-        inBuffer.clear();
-        outBuffer.flip();
+        ((Buffer)inBuffer).clear();
+        ((Buffer)outBuffer).flip();
     }
 
     /**
@@ -563,8 +564,8 @@ public class CryptoInputStream extends InputStream implements
      */
     protected void decryptFinal() throws IOException {
         // Prepare the input buffer and clear the out buffer
-        inBuffer.flip();
-        outBuffer.clear();
+        ((Buffer)inBuffer).flip();
+        ((Buffer)outBuffer).clear();
 
         try {
             cipher.doFinal(inBuffer, outBuffer);
@@ -578,8 +579,8 @@ public class CryptoInputStream extends InputStream implements
         }
 
         // Clear the input buffer and prepare out buffer
-        inBuffer.clear();
-        outBuffer.flip();
+        ((Buffer)inBuffer).clear();
+        ((Buffer)outBuffer).flip();
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
@@ -20,6 +20,7 @@ package org.apache.commons.crypto.stream;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.security.InvalidAlgorithmParameterException;
@@ -314,12 +315,12 @@ public class CryptoOutputStream extends OutputStream implements
                 // to void copy twice, we set the limit to copy directly
                 final int oldLimit = src.limit();
                 final int newLimit = src.position() + space;
-                src.limit(newLimit);
+                ((Buffer)src).limit(newLimit);
 
                 inBuffer.put(src);
 
                 // restore the old limit
-                src.limit(oldLimit);
+                ((Buffer)src).limit(oldLimit);
 
                 remaining -= space;
                 encrypt();
@@ -352,8 +353,8 @@ public class CryptoOutputStream extends OutputStream implements
      */
     protected void encrypt() throws IOException {
 
-        inBuffer.flip();
-        outBuffer.clear();
+        ((Buffer)inBuffer).flip();
+        ((Buffer)outBuffer).clear();
 
         try {
             cipher.update(inBuffer, outBuffer);
@@ -361,8 +362,8 @@ public class CryptoOutputStream extends OutputStream implements
             throw new IOException(e);
         }
 
-        inBuffer.clear();
-        outBuffer.flip();
+        ((Buffer)inBuffer).clear();
+        ((Buffer)outBuffer).flip();
 
         // write to output
         while (outBuffer.hasRemaining()) {
@@ -376,8 +377,8 @@ public class CryptoOutputStream extends OutputStream implements
      * @throws IOException if an I/O error occurs.
      */
     protected void encryptFinal() throws IOException {
-        inBuffer.flip();
-        outBuffer.clear();
+        ((Buffer)inBuffer).flip();
+        ((Buffer)outBuffer).clear();
 
         try {
             cipher.doFinal(inBuffer, outBuffer);
@@ -389,8 +390,8 @@ public class CryptoOutputStream extends OutputStream implements
             throw new IOException(e);
         }
 
-        inBuffer.clear();
-        outBuffer.flip();
+        ((Buffer)inBuffer).clear();
+        ((Buffer)outBuffer).flip();
 
         // write to output
         while (outBuffer.hasRemaining()) {

--- a/src/main/java/org/apache/commons/crypto/stream/CtrCryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CtrCryptoInputStream.java
@@ -19,6 +19,7 @@ package org.apache.commons.crypto.stream;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.security.InvalidAlgorithmParameterException;
@@ -269,7 +270,7 @@ public class CtrCryptoInputStream extends CryptoInputStream {
             return 0;
         } else if (n <= outBuffer.remaining()) {
             final int pos = outBuffer.position() + (int) n;
-            outBuffer.position(pos);
+            ((Buffer)outBuffer).position(pos);
             return n;
         } else {
             /*
@@ -327,9 +328,9 @@ public class CtrCryptoInputStream extends CryptoInputStream {
         final int toRead = buf.remaining();
         if (toRead <= unread) {
             final int limit = outBuffer.limit();
-            outBuffer.limit(outBuffer.position() + toRead);
+            ((Buffer)outBuffer).limit(outBuffer.position() + toRead);
             buf.put(outBuffer);
-            outBuffer.limit(limit);
+            ((Buffer)outBuffer).limit(limit);
             return toRead;
         }
         buf.put(outBuffer);
@@ -353,7 +354,7 @@ public class CtrCryptoInputStream extends CryptoInputStream {
         if (position >= getStreamPosition() && position <= getStreamOffset()) {
             final int forward = (int) (position - getStreamPosition());
             if (forward > 0) {
-                outBuffer.position(outBuffer.position() + forward);
+                ((Buffer)outBuffer).position(outBuffer.position() + forward);
             }
         } else {
             input.seek(position);
@@ -423,18 +424,18 @@ public class CtrCryptoInputStream extends CryptoInputStream {
             return;
         }
 
-        inBuffer.flip();
-        outBuffer.clear();
+        ((Buffer)inBuffer).flip();
+        ((Buffer)outBuffer).clear();
         decryptBuffer(outBuffer);
-        inBuffer.clear();
-        outBuffer.flip();
+        ((Buffer)inBuffer).clear();
+        ((Buffer)outBuffer).flip();
 
         if (padding > 0) {
             /*
              * The plain text and cipher text have a 1:1 mapping, they start at
              * the same position.
              */
-            outBuffer.position(padding);
+            ((Buffer)outBuffer).position(padding);
         }
     }
 
@@ -458,9 +459,9 @@ public class CtrCryptoInputStream extends CryptoInputStream {
             // There is no real data in inBuffer.
             return;
         }
-        inBuffer.flip();
+        ((Buffer)inBuffer).flip();
         decryptBuffer(buf);
-        inBuffer.clear();
+        ((Buffer)inBuffer).clear();
     }
 
     /**
@@ -479,21 +480,21 @@ public class CtrCryptoInputStream extends CryptoInputStream {
         final int limit = buf.limit();
         int n = 0;
         while (n < len) {
-            buf.position(offset + n);
-            buf.limit(offset + n + Math.min(len - n, inBuffer.remaining()));
+            ((Buffer)buf).position(offset + n);
+            ((Buffer)buf).limit(offset + n + Math.min(len - n, inBuffer.remaining()));
             inBuffer.put(buf);
             // Do decryption
             try {
                 decrypt();
-                buf.position(offset + n);
-                buf.limit(limit);
+                ((Buffer)buf).position(offset + n);
+                ((Buffer)buf).limit(limit);
                 n += outBuffer.remaining();
                 buf.put(outBuffer);
             } finally {
                 padding = postDecryption(streamOffset - (len - n));
             }
         }
-        buf.position(pos);
+        ((Buffer)buf).position(pos);
     }
 
     /**
@@ -515,7 +516,7 @@ public class CtrCryptoInputStream extends CryptoInputStream {
              */
             resetCipher(position);
             padding = getPadding(position);
-            inBuffer.position(padding);
+            ((Buffer)inBuffer).position(padding);
         }
         return padding;
     }
@@ -587,12 +588,12 @@ public class CtrCryptoInputStream extends CryptoInputStream {
      */
     protected void resetStreamOffset(final long offset) throws IOException {
         streamOffset = offset;
-        inBuffer.clear();
-        outBuffer.clear();
-        outBuffer.limit(0);
+        ((Buffer)inBuffer).clear();
+        ((Buffer)outBuffer).clear();
+        ((Buffer)outBuffer).limit(0);
         resetCipher(offset);
         padding = getPadding(offset);
-        inBuffer.position(padding); // Set proper position for input data.
+        ((Buffer)inBuffer).position(padding); // Set proper position for input data.
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/stream/CtrCryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CtrCryptoOutputStream.java
@@ -19,6 +19,7 @@ package org.apache.commons.crypto.stream;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.security.InvalidAlgorithmParameterException;
@@ -272,18 +273,18 @@ public class CtrCryptoOutputStream extends CryptoOutputStream {
             return;
         }
 
-        inBuffer.flip();
-        outBuffer.clear();
+        ((Buffer)inBuffer).flip();
+        ((Buffer)outBuffer).clear();
         encryptBuffer(outBuffer);
-        inBuffer.clear();
-        outBuffer.flip();
+        ((Buffer)inBuffer).clear();
+        ((Buffer)outBuffer).flip();
 
         if (padding > 0) {
             /*
              * The plain text and cipher text have a 1:1 mapping, they start at
              * the same position.
              */
-            outBuffer.position(padding);
+            ((Buffer)outBuffer).position(padding);
             padding = 0;
         }
 
@@ -330,7 +331,7 @@ public class CtrCryptoOutputStream extends CryptoOutputStream {
         final long counter = streamOffset
                 / cipher.getBlockSize();
         padding = (byte) (streamOffset % cipher.getBlockSize());
-        inBuffer.position(padding); // Set proper position for input data.
+        ((Buffer)inBuffer).position(padding); // Set proper position for input data.
 
         CtrCryptoInputStream.calculateIV(initIV, counter, iv);
         try {

--- a/src/main/java/org/apache/commons/crypto/stream/PositionedCryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/PositionedCryptoInputStream.java
@@ -18,6 +18,7 @@
 package org.apache.commons.crypto.stream;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
@@ -174,7 +175,7 @@ public class PositionedCryptoInputStream extends CtrCryptoInputStream {
             final byte[] iv = getInitIV().clone();
             resetCipher(state, position, iv);
             byte padding = getPadding(position);
-            inByteBuffer.position(padding); // Set proper position for input data.
+            ((Buffer)inByteBuffer).position(padding); // Set proper position for input data.
 
             int n = 0;
             while (n < length) {
@@ -213,17 +214,17 @@ public class PositionedCryptoInputStream extends CtrCryptoInputStream {
             // There is no real data in inBuffer.
             return;
         }
-        inByteBuffer.flip();
-        outByteBuffer.clear();
+        ((Buffer)inByteBuffer).flip();
+        ((Buffer)outByteBuffer).clear();
         decryptBuffer(state, inByteBuffer, outByteBuffer);
-        inByteBuffer.clear();
-        outByteBuffer.flip();
+        ((Buffer)inByteBuffer).clear();
+        ((Buffer)outByteBuffer).flip();
         if (padding > 0) {
             /*
              * The plain text and cipher text have a 1:1 mapping, they start at
              * the same position.
              */
-            outByteBuffer.position(padding);
+            ((Buffer)outByteBuffer).position(padding);
         }
     }
 
@@ -281,7 +282,7 @@ public class PositionedCryptoInputStream extends CtrCryptoInputStream {
              */
             resetCipher(state, position, iv);
             padding = getPadding(position);
-            inByteBuffer.position(padding);
+            ((Buffer)inByteBuffer).position(padding);
         }
         return padding;
     }
@@ -362,7 +363,7 @@ public class PositionedCryptoInputStream extends CtrCryptoInputStream {
      */
     private void returnBuffer(final ByteBuffer buf) {
         if (buf != null) {
-            buf.clear();
+            ((Buffer)buf).clear();
             bufferPool.add(buf);
         }
     }

--- a/src/main/java/org/apache/commons/crypto/stream/input/ChannelInput.java
+++ b/src/main/java/org/apache/commons/crypto/stream/input/ChannelInput.java
@@ -18,6 +18,7 @@
 package org.apache.commons.crypto.stream.input;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 
@@ -79,8 +80,8 @@ public class ChannelInput implements Input {
         final int size = (int) Math.min(SKIP_BUFFER_SIZE, remaining);
         final ByteBuffer skipBuffer = getSkipBuf();
         while (remaining > 0) {
-            skipBuffer.clear();
-            skipBuffer.limit((int) Math.min(size, remaining));
+            ((Buffer)skipBuffer).clear();
+            ((Buffer)skipBuffer).limit((int) Math.min(size, remaining));
             nr = read(skipBuffer);
             if (nr < 0) {
                 break;

--- a/src/test/java/org/apache/commons/crypto/cipher/GcmCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/GcmCipherTest.java
@@ -27,7 +27,6 @@ import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.apache.commons.crypto.utils.Utils;
 import org.junit.Assert;
@@ -352,11 +351,11 @@ public class GcmCipherTest {
     private void testGcmEncryption(final String kHex, final String pHex, final String ivHex, final String aadHex,
                                    final String cHex, final String tHex) throws Exception {
 
-        final byte[] keyBytes = DatatypeConverter.parseHexBinary(kHex);
-        final byte[] input = DatatypeConverter.parseHexBinary(pHex);
-        final byte[] ivBytes = DatatypeConverter.parseHexBinary(ivHex);
-        final byte[] aad = DatatypeConverter.parseHexBinary(aadHex);
-        final byte[] expectedOutput = DatatypeConverter.parseHexBinary(cHex+tHex);
+        final byte[] keyBytes = AbstractCipherTest.parseHexBinary(kHex);
+        final byte[] input = AbstractCipherTest.parseHexBinary(pHex);
+        final byte[] ivBytes = AbstractCipherTest.parseHexBinary(ivHex);
+        final byte[] aad = AbstractCipherTest.parseHexBinary(aadHex);
+        final byte[] expectedOutput = AbstractCipherTest.parseHexBinary(cHex+tHex);
 
         final byte[] output = new byte[expectedOutput.length];
 
@@ -377,11 +376,11 @@ public class GcmCipherTest {
     private void testGcmArbitraryLengthUpdate(final String kHex, final String pHex, final String ivHex, final String aadHex,
                                               final String cHex, final String tHex) throws Exception {
 
-        final byte[] keyBytes = DatatypeConverter.parseHexBinary(kHex);
-        final byte[] input = DatatypeConverter.parseHexBinary(pHex);
-        final byte[] ivBytes = DatatypeConverter.parseHexBinary(ivHex);
-        final byte[] aad = DatatypeConverter.parseHexBinary(aadHex);
-        final byte[] expectedOutput = DatatypeConverter.parseHexBinary(cHex+tHex);
+        final byte[] keyBytes = AbstractCipherTest.parseHexBinary(kHex);
+        final byte[] input = AbstractCipherTest.parseHexBinary(pHex);
+        final byte[] ivBytes = AbstractCipherTest.parseHexBinary(ivHex);
+        final byte[] aad = AbstractCipherTest.parseHexBinary(aadHex);
+        final byte[] expectedOutput = AbstractCipherTest.parseHexBinary(cHex+tHex);
 
         final byte[] encOutput = new byte[expectedOutput.length];
         final byte[] decOutput = new byte[input.length];
@@ -434,12 +433,12 @@ public class GcmCipherTest {
     private void testGcmDecryption(final String kHex, final String pHex, final String ivHex, final String aadHex,
                                    final String cHex, final String tHex) throws Exception {
 
-        final byte[] keyBytes = DatatypeConverter.parseHexBinary(kHex);
-        final byte[] plainBytes = DatatypeConverter.parseHexBinary(pHex);
-        final byte[] ivBytes = DatatypeConverter.parseHexBinary(ivHex);
+        final byte[] keyBytes = AbstractCipherTest.parseHexBinary(kHex);
+        final byte[] plainBytes = AbstractCipherTest.parseHexBinary(pHex);
+        final byte[] ivBytes = AbstractCipherTest.parseHexBinary(ivHex);
 
-        final byte[] aad = DatatypeConverter.parseHexBinary(aadHex);
-        final byte[] cipherBytes = DatatypeConverter.parseHexBinary(cHex+tHex);
+        final byte[] aad = AbstractCipherTest.parseHexBinary(aadHex);
+        final byte[] cipherBytes = AbstractCipherTest.parseHexBinary(cHex+tHex);
 
         final byte[] input = cipherBytes;
         final byte[] output = new byte[plainBytes.length];
@@ -460,12 +459,12 @@ public class GcmCipherTest {
     private void testGcmReturnDataAfterTagVerified(final String kHex, final String pHex, final String ivHex, final String aadHex,
                                                    final String cHex, final String tHex) throws Exception {
 
-        final byte[] keyBytes = DatatypeConverter.parseHexBinary(kHex);
-        final byte[] plainBytes = DatatypeConverter.parseHexBinary(pHex);
-        final byte[] ivBytes = DatatypeConverter.parseHexBinary(ivHex);
+        final byte[] keyBytes = AbstractCipherTest.parseHexBinary(kHex);
+        final byte[] plainBytes = AbstractCipherTest.parseHexBinary(pHex);
+        final byte[] ivBytes = AbstractCipherTest.parseHexBinary(ivHex);
 
-        final byte[] aad = DatatypeConverter.parseHexBinary(aadHex);
-        final byte[] cipherBytes = DatatypeConverter.parseHexBinary(cHex+tHex);
+        final byte[] aad = AbstractCipherTest.parseHexBinary(aadHex);
+        final byte[] cipherBytes = AbstractCipherTest.parseHexBinary(cHex+tHex);
 
         final byte[] input = cipherBytes;
         final byte[] output = new byte[plainBytes.length];
@@ -491,11 +490,11 @@ public class GcmCipherTest {
     private void testGcmByteBuffer(final String kHex, final String pHex, final String ivHex, final String aadHex,
                                    final String cHex, final String tHex) throws Exception {
 
-        final byte[] keyBytes = DatatypeConverter.parseHexBinary(kHex);
-        final byte[] plainText = DatatypeConverter.parseHexBinary(pHex);
-        final byte[] ivBytes = DatatypeConverter.parseHexBinary(ivHex);
-        final byte[] aad = DatatypeConverter.parseHexBinary(aadHex);
-        final byte[] cipherText = DatatypeConverter.parseHexBinary(cHex+tHex);
+        final byte[] keyBytes = AbstractCipherTest.parseHexBinary(kHex);
+        final byte[] plainText = AbstractCipherTest.parseHexBinary(pHex);
+        final byte[] ivBytes = AbstractCipherTest.parseHexBinary(ivHex);
+        final byte[] aad = AbstractCipherTest.parseHexBinary(aadHex);
+        final byte[] cipherText = AbstractCipherTest.parseHexBinary(cHex+tHex);
 
         final byte[] encOutput = new byte[cipherText.length];
         final byte[] decOutput = new byte[plainText.length];


### PR DESCRIPTION
This PR contains modifications that adds support for Java 9 to Java 11.  Primary modifications for review and discussion include:

1.  The makefile includes a JDK version check and adds javac -h logic for major Java versions greater than eight.
2.  I removed the DataTypConverter class and replaced it with local methods.  These local methods were simply copy-pasted from the DataTypeConverter source and added to the abstract base test class.  DataTypeConverter was the only class that is in JDK8 but is not in JDK11, and it's only used for tests.  I could have added a build profile including the DataTypConverter dependency for JDK 11 builds, but I opted to change the source so that the tests will run on Java 11 even if it was built on Java 8.
3.  The JDK11 build was pushing out a bunch of changed return covariant messages.  Not the end of the world, but annoying, so I included a cast to each of the offending methods to remove the build message.
4.  Particularly vexing from a troubleshooting perspective was that JDK10 and JDK11 builds were intermittently SegFaulting.  I happened across a discussion that pointed to the Surefire plugin as the culprit.  After experimenting with some different plugin version combinations, the only way I could prevent the VM crash was to disable fork reuse in the plugin config.  This slows the tests down noticeably, but not prohibitively.
5.  Finally, I replaced three existing Travis builds with Java 11.  I thought it would have been overkill to re-run each of the existing seven Java 8 builds with Java 11.  I don't think it's practical to test every OS/JDK/OpenSSl Version combination that Commons Crypto supports, but we can debate where the happy medium lies.

I look forward to your comments and recommendations.