### PR TITLE
Standardize the release build process with Docker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
          - OPENSSL_HOME=/usr/
       install: |
         sudo ln -s /usr/include/x86_64-linux-gnu /usr/include/i386-linux-gnu
+        mvn -version
         mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V --no-transfer-progress
         mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Plinux32 --no-transfer-progress
 
@@ -53,6 +54,7 @@ matrix:
          - OPENSSL_HOME=/usr/
       install: |
         sudo ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/opensslconf.h
+        mvn -version
         mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pwin64 --no-transfer-progress
         mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pwin32 --no-transfer-progress
       script: echo DONE

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ matrix:
          - OPENSSL_HOME=/usr/
       install: |
         sudo ln -s /usr/include/x86_64-linux-gnu /usr/include/i386-linux-gnu
-        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Plinux32
+        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V --no-transfer-progress
+        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Plinux32 --no-transfer-progress
 
     # Job tests win32,win64 builds. But cannot test execution.
     - name: "win32,win64 / Ubuntu 14.04 / Java 8 / OpenSSL 1.0.x"
@@ -53,8 +53,8 @@ matrix:
          - OPENSSL_HOME=/usr/
       install: |
         sudo ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/opensslconf.h
-        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pwin64
-        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pwin32
+        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pwin64 --no-transfer-progress
+        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pwin32 --no-transfer-progress
       script: echo DONE
       after_success: echo DONE
 
@@ -129,9 +129,9 @@ before_install:
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
   - openssl version -a
-install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Denforcer.skip=true -B -V
-script: mvn test jacoco:report coveralls:report -Denforcer.skip=true -B -V
-after_success: mvn site -Denforcer.skip=true -B -V
+install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Denforcer.skip=true -B -V --no-transfer-progress
+script: mvn test jacoco:report coveralls:report -Denforcer.skip=true -B -V --no-transfer-progress
+after_success: mvn site -Denforcer.skip=true -B -V --no-transfer-progress
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   include:
 
     # This job tests x64 and i386 builds. Tests x64 for proper execution.
+    # Can't use --no-transfer-progress before Maven 3.6.1.
     - name: "x64,i386 / Ubuntu 14.04 / Java 8 / OpenSSL 1.0.x"
       arch: amd64
       os: linux
@@ -35,8 +36,8 @@ matrix:
       install: |
         sudo ln -s /usr/include/x86_64-linux-gnu /usr/include/i386-linux-gnu
         mvn -version
-        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V --no-transfer-progress
-        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Plinux32 --no-transfer-progress
+        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Plinux32
 
     # Job tests win32,win64 builds. But cannot test execution.
     - name: "win32,win64 / Ubuntu 14.04 / Java 8 / OpenSSL 1.0.x"
@@ -55,8 +56,8 @@ matrix:
       install: |
         sudo ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/opensslconf.h
         mvn -version
-        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pwin64 --no-transfer-progress
-        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pwin32 --no-transfer-progress
+        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pwin64
+        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pwin32
       script: echo DONE
       after_success: echo DONE
 
@@ -131,9 +132,9 @@ before_install:
     sudo unzip -j -o /tmp/policy.zip *.jar -d $JAVA_HOME/jre/lib/security
     rm /tmp/policy.zip
   - openssl version -a
-install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Denforcer.skip=true -B -V --no-transfer-progress
-script: mvn test jacoco:report coveralls:report -Denforcer.skip=true -B -V --no-transfer-progress
-after_success: mvn site -Denforcer.skip=true -B -V --no-transfer-progress
+install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Denforcer.skip=true -B -V
+script: mvn test jacoco:report coveralls:report -Denforcer.skip=true -B -V
+after_success: mvn site -Denforcer.skip=true -B -V
 
 cache:
   directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,26 +13,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file builds the Linux-x86_64, Linux-arm, Linux-armfh. Linux aarch64 and Win64 jnilibs.  It copies the contents of
-# the build host's project directory (commons-crypto) into the docker image and cross compiles the remaining builds. If 
-# you run this script from a Mac after a successful build, the build in the resuing Docker image will include the Mac 
-# build.
+# This file runs builds for the Linux-x86_64, Linux aarch64, Linux-arm, Linux-armfh and Win64 
+# architectures.  It copies the contents of the build host's project directory (commons-crypto) 
+# into the docker image, builds and tests the x86_64 build natively, and then cross compiles the 
+# remaining builds.  If you run this script from a Mac after a successful build, the build in the 
+# resuing Docker image will also include the Mac build by virtue of the initial project directory 
+# copy.
 
-FROM ubuntu:18.04
+FROM ubuntu:14.04
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-# Install dependencies and tooling.
-RUN dpkg --add-architecture i386 && apt-get update && apt-get --assume-yes install build-essential \
-      && apt-get --assume-yes install openjdk-8-jdk && apt-get --assume-yes install maven \
-      && apt-get --assume-yes install libssl-dev:i386 && apt-get --assume-yes install libssl-dev \
-      && apt-get --assume-yes install gcc-arm-linux-gnueabi && apt-get --assume-yes install g++-arm-linux-gnueabi \
-      && apt-get --assume-yes install gcc-arm-linux-gnueabihf && apt-get --assume-yes install g++-arm-linux-gnueabihf \
-      && apt-get --assume-yes install gcc-aarch64-linux-gnu && apt-get --assume-yes install g++-aarch64-linux-gnu \
+ENV MAVEN_HOME=/opt/maven
+ENV PATH=${MAVEN_HOME}/bin:${PATH}
+# Install 64-bit dependencies and tooling.
+RUN apt-get update && apt-get --assume-yes install software-properties-common \
+      && add-apt-repository ppa:openjdk-r/ppa && apt-get update \
+      && apt-get --assume-yes install openjdk-8-jdk \
+      && apt-get --assume-yes install build-essential \
+      && apt-get --assume-yes install libssl-dev \
+      && apt-get --assume-yes install gcc-aarch64-linux-gnu \
+      && apt-get --assume-yes install g++-aarch64-linux-gnu \
       && apt-get --assume-yes install mingw-w64 \
-# Copy the opensslconf.h file to the base openssl include directory
+      && apt-get --assume-yes install wget \
+# Bug workaround see https://github.com/docker-library/openjdk/issues/19.
+      && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
+# The default Maven with 14.04 doesn't support the required HTTPS protocol by default.
+      && wget https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
+      && tar xf apache-maven-*.tar.gz -C /opt && ln -s /opt/apache-maven-3.6.3 /opt/maven \
+# Copy the opensslconf.h file to the base openssl include directory.
       && cp /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl \
 # Create the build directory.
       && mkdir commons-crypto 
 COPY . /commons-crypto
-# Run the base Linux x86_64 build with tests and then run the cross-compile builds without.
-RUN cd commons-crypto && mvn package && mvn -DskipTests package -P linux-arm && mvn -DskipTests package -P linux-armhf \
-      && mvn -DskipTests package -P linux-aarch64 && mvn -DskipTests package -P win64
+# Run the 64-bit builds.
+RUN cd commons-crypto && mvn package && mvn -DskipTests package -P linux-aarch64 \
+      && mvn -DskipTests package -P win64 \
+# Install 32-bit dependencies and tooling.
+      && dpkg --add-architecture i386 && apt-get update \
+      && apt-get --assume-yes install libssl-dev:i386 \
+      && apt-get --assume-yes install gcc-arm-linux-gnueabi \
+      && apt-get --assume-yes install g++-arm-linux-gnueabi \
+      && apt-get --assume-yes install gcc-arm-linux-gnueabihf \
+      && apt-get --assume-yes install g++-arm-linux-gnueabihf \
+# Run the 32-bit builds.
+      && mvn -DskipTests package -P linux-arm && mvn -DskipTests package -P linux-armhf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file builds the Linux-x86_64, Linux-arm, Linux-armfh. Linux aarch64 and Win64 jnilibs.  It copies the contents of
+# the build host's project directory (commons-crypto) into the docker image and cross compiles the remaining builds. If 
+# you run this script from a Mac after a successful build, the build in the resuing Docker image will include the Mac 
+# build.
+
+FROM ubuntu:18.04
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+RUN dpkg --add-architecture i386 && apt-get update && apt-get --assume-yes install build-essential \
+      && apt-get --assume-yes install openjdk-8-jdk && apt-get --assume-yes install maven \
+      && apt-get --assume-yes install libssl-dev:i386 && apt-get --assume-yes install libssl-dev \
+      && apt-get --assume-yes install gcc-arm-linux-gnueabi && apt-get --assume-yes install g++-arm-linux-gnueabi \
+      && apt-get --assume-yes install gcc-arm-linux-gnueabihf && apt-get --assume-yes install g++-arm-linux-gnueabihf \
+      && apt-get --assume-yes install gcc-aarch64-linux-gnu && apt-get --assume-yes install g++-aarch64-linux-gnu \
+      && apt-get --assume-yes install mingw-w64 && apt-get --assume-yes install wget && apt-get --assume-yes install curl
+RUN mkdir commons-crypto 
+COPY . /commons-crypto
+RUN cd commons-crypto && mvn package
+# Build openssl from source to generate the platform-specific opensslconf.h for the cross-compilers
+RUN wget https://www.openssl.org/source/openssl-1.1.1.tar.gz && tar -xvzf openssl-1.1.1.tar.gz && cd openssl-1.1.1 \
+      && ./Configure mingw64 shared --cross-compile-prefix=x86_64-w64-mingw32- && make 
+RUN cd commons-crypto && mvn -DskipTests package -P win64
+RUN cd openssl-1.1.1 && make clean && ./Configure linux-armv4 shared --cross-compile-prefix=arm-linux-gnueabi- && make 
+RUN cd commons-crypto && mvn -DskipTests package -P linux-arm && mvn -DskipTests package -P linux-armhf
+RUN cd openssl-1.1.1 && make clean && ./Configure linux-aarch64 shared --cross-compile-prefix=aarch64-linux-gnu- && make 
+RUN cd commons-crypto && mvn -DskipTests package -P linux-aarch64

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,10 @@ RUN dpkg --add-architecture i386 && apt-get update && apt-get --assume-yes insta
       && apt-get --assume-yes install gcc-arm-linux-gnueabi && apt-get --assume-yes install g++-arm-linux-gnueabi \
       && apt-get --assume-yes install gcc-arm-linux-gnueabihf && apt-get --assume-yes install g++-arm-linux-gnueabihf \
       && apt-get --assume-yes install gcc-aarch64-linux-gnu && apt-get --assume-yes install g++-aarch64-linux-gnu \
-      && apt-get --assume-yes install mingw-w64 && apt-get --assume-yes install wget && apt-get --assume-yes install curl
-RUN mkdir commons-crypto 
+      && apt-get --assume-yes install mingw-w64 && apt-get --assume-yes install wget && apt-get --assume-yes install curl \
+      && mkdir commons-crypto && cp /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl
 COPY . /commons-crypto
 RUN cd commons-crypto && mvn package
 # Build openssl from source to generate the platform-specific opensslconf.h for the cross-compilers
-RUN wget https://www.openssl.org/source/openssl-1.1.1.tar.gz && tar -xvzf openssl-1.1.1.tar.gz && cd openssl-1.1.1 \
-      && ./Configure mingw64 shared --cross-compile-prefix=x86_64-w64-mingw32- && make 
-RUN cd commons-crypto && mvn -DskipTests package -P win64
-RUN cd openssl-1.1.1 && make clean && ./Configure linux-armv4 shared --cross-compile-prefix=arm-linux-gnueabi- && make 
-RUN cd commons-crypto && mvn -DskipTests package -P linux-arm && mvn -DskipTests package -P linux-armhf
-RUN cd openssl-1.1.1 && make clean && ./Configure linux-aarch64 shared --cross-compile-prefix=aarch64-linux-gnu- && make 
-RUN cd commons-crypto && mvn -DskipTests package -P linux-aarch64
+RUN cd commons-crypto && mvn -DskipTests package -P linux-arm && mvn -DskipTests package -P linux-armhf 
+RUN cd commons-crypto && mvn -DskipTests package -P linux-aarch64 && mvn -DskipTests package -P win64

--- a/Makefile.common
+++ b/Makefile.common
@@ -154,7 +154,7 @@ SunOS-x86_64_COMMONS_CRYPTO_FLAGS  :=
 Linux-arm_CC        := $(CROSS_PREFIX)gcc
 Linux-arm_CXX       := $(CROSS_PREFIX)g++
 Linux-arm_STRIP     := $(CROSS_PREFIX)strip
-Linux-arm_CFLAGS    := -include lib/inc_linux/jni_md.h -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
+Linux-arm_CFLAGS    := -I/openssl-1.1.1/include -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
 Linux-arm_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
 Linux-arm_LINKFLAGS := -shared -static-libgcc
 Linux-arm_LIBNAME   := libcommons-crypto.so
@@ -163,7 +163,7 @@ Linux-arm_COMMONS_CRYPTO_FLAGS:=
 Linux-armhf_CC        := $(CROSS_PREFIX)gcc
 Linux-armhf_CXX       := $(CROSS_PREFIX)g++
 Linux-armhf_STRIP     := $(CROSS_PREFIX)strip
-Linux-armhf_CFLAGS    := -include lib/inc_linux/jni_md.h -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
+Linux-armhf_CFLAGS    := -I/openssl-1.1.1/include -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
 Linux-armhf_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
 Linux-armhf_LINKFLAGS := -shared -static-libgcc
 Linux-armhf_LIBNAME   := libcommons-crypto.so
@@ -172,8 +172,8 @@ Linux-armhf_COMMONS_CRYPTO_FLAGS:=
 Linux-aarch64_CC        := $(CROSS_PREFIX)gcc
 Linux-aarch64_CXX       := $(CROSS_PREFIX)g++
 Linux-aarch64_STRIP     := $(CROSS_PREFIX)strip
-Linux-aarch64_CXXFLAGS  := -Ilib/inc_linux -I"$(JAVA_HOME)/include" -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -Wall -Werror
-Linux-aarch64_CFLAGS    := -Ilib/inc_linux -I"$(JAVA_HOME)/include" -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -Wall -Werror
+Linux-aarch64_CXXFLAGS  := -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -Wall -Werror
+Linux-aarch64_CFLAGS    := -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -Wall -Werror
 Linux-aarch64_LINKFLAGS := -shared -static-libgcc
 Linux-aarch64_LIBNAME   := libcommons-crypto.so
 Linux-aarch64_COMMONS_CRYPTO_FLAGS  :=
@@ -190,8 +190,8 @@ Mac-x86_COMMONS_CRYPTO_FLAGS  :=
 Mac-x86_64_CC        := gcc -arch $(OS_ARCH)
 Mac-x86_64_CXX       := gcc -arch $(OS_ARCH)
 Mac-x86_64_STRIP     := strip -x
-Mac-x86_64_CFLAGS    := -Ilib/inc_mac -I"$(JAVA_HOME)/include" -O2 -fPIC -mmacosx-version-min=10.7 -fvisibility=hidden -I/usr/local/include -I/usr/local/opt/openssl/include
-Mac-x86_64_CXXFLAGS  := -Ilib/inc_mac -I"$(JAVA_HOME)/include" -O2 -fPIC -mmacosx-version-min=10.7 -fvisibility=hidden -I/usr/local/include -I/usr/local/opt/openssl/include
+Mac-x86_64_CFLAGS    := -Ilib/inc_mac -I"$(JAVA_HOME)/include" -O2 -fPIC -mmacosx-version-min=10.10 -fvisibility=hidden -I/usr/local/include -I/usr/local/opt/openssl/include
+Mac-x86_64_CXXFLAGS  := -Ilib/inc_mac -I"$(JAVA_HOME)/include" -O2 -fPIC -mmacosx-version-min=10.10 -fvisibility=hidden -I/usr/local/include -I/usr/local/opt/openssl/include
 Mac-x86_64_LINKFLAGS := -dynamiclib -L/usr/local/lib
 Mac-x86_64_LIBNAME   := libcommons-crypto.jnilib
 Mac-x86_64_COMMONS_CRYPTO_FLAGS  :=
@@ -217,7 +217,7 @@ Windows-x86_COMMONS_CRYPTO_FLAGS :=
 Windows-x86_64_CC           := $(CROSS_PREFIX)gcc
 Windows-x86_64_CXX          := $(CROSS_PREFIX)g++
 Windows-x86_64_STRIP        := $(CROSS_PREFIX)strip
-Windows-x86_64_CFLAGS       := -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -I"$(OPENSSL_HOME)/include" -Ilib/inc_win -O2 -fno-inline
+Windows-x86_64_CFLAGS       := -I/openssl-1.1.1/include -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -O2 -fno-inline
 Windows-x86_64_CXXFLAGS     := -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -I"$(OPENSSL_HOME)/include" -Ilib/inc_win -O2 -fno-inline
 Windows-x86_64_LINKFLAGS    := -Wl,--kill-at -shared -static
 Windows-x86_64_LIBNAME      := commons-crypto.dll

--- a/Makefile.common
+++ b/Makefile.common
@@ -154,8 +154,8 @@ SunOS-x86_64_COMMONS_CRYPTO_FLAGS  :=
 Linux-arm_CC        := $(CROSS_PREFIX)gcc
 Linux-arm_CXX       := $(CROSS_PREFIX)g++
 Linux-arm_STRIP     := $(CROSS_PREFIX)strip
-Linux-arm_CFLAGS    := -I/openssl-1.1.1/include -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
-Linux-arm_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
+Linux-arm_CFLAGS    := -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
+Linux-arm_CXXFLAGS  := -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
 Linux-arm_LINKFLAGS := -shared -static-libgcc
 Linux-arm_LIBNAME   := libcommons-crypto.so
 Linux-arm_COMMONS_CRYPTO_FLAGS:=
@@ -172,8 +172,8 @@ Linux-armhf_COMMONS_CRYPTO_FLAGS:=
 Linux-aarch64_CC        := $(CROSS_PREFIX)gcc
 Linux-aarch64_CXX       := $(CROSS_PREFIX)g++
 Linux-aarch64_STRIP     := $(CROSS_PREFIX)strip
-Linux-aarch64_CXXFLAGS  := -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -Wall -Werror
-Linux-aarch64_CFLAGS    := -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -Wall -Werror
+Linux-aarch64_CXXFLAGS  := -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -Wall -Werror
+Linux-aarch64_CFLAGS    := -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -Wall -Werror
 Linux-aarch64_LINKFLAGS := -shared -static-libgcc
 Linux-aarch64_LIBNAME   := libcommons-crypto.so
 Linux-aarch64_COMMONS_CRYPTO_FLAGS  :=
@@ -190,8 +190,8 @@ Mac-x86_COMMONS_CRYPTO_FLAGS  :=
 Mac-x86_64_CC        := gcc -arch $(OS_ARCH)
 Mac-x86_64_CXX       := gcc -arch $(OS_ARCH)
 Mac-x86_64_STRIP     := strip -x
-Mac-x86_64_CFLAGS    := -Ilib/inc_mac -I"$(JAVA_HOME)/include" -O2 -fPIC -mmacosx-version-min=10.10 -fvisibility=hidden -I/usr/local/include -I/usr/local/opt/openssl/include
-Mac-x86_64_CXXFLAGS  := -Ilib/inc_mac -I"$(JAVA_HOME)/include" -O2 -fPIC -mmacosx-version-min=10.10 -fvisibility=hidden -I/usr/local/include -I/usr/local/opt/openssl/include
+Mac-x86_64_CFLAGS    := -I"$(JAVA_HOME)/include" -O2 -fPIC -mmacosx-version-min=10.10 -fvisibility=hidden -I/usr/local/include -I/usr/local/opt/openssl/include
+Mac-x86_64_CXXFLAGS  := -I"$(JAVA_HOME)/include" -O2 -fPIC -mmacosx-version-min=10.10 -fvisibility=hidden -I/usr/local/include -I/usr/local/opt/openssl/include
 Mac-x86_64_LINKFLAGS := -dynamiclib -L/usr/local/lib
 Mac-x86_64_LIBNAME   := libcommons-crypto.jnilib
 Mac-x86_64_COMMONS_CRYPTO_FLAGS  :=

--- a/Makefile.common
+++ b/Makefile.common
@@ -163,8 +163,8 @@ Linux-arm_COMMONS_CRYPTO_FLAGS:=
 Linux-armhf_CC        := $(CROSS_PREFIX)gcc
 Linux-armhf_CXX       := $(CROSS_PREFIX)g++
 Linux-armhf_STRIP     := $(CROSS_PREFIX)strip
-Linux-armhf_CFLAGS    := -I/openssl-1.1.1/include -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
-Linux-armhf_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
+Linux-armhf_CFLAGS    := -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
+Linux-armhf_CXXFLAGS  := -I"$(JAVA_HOME)/include" -I/usr/include/i386-linux-gnu -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
 Linux-armhf_LINKFLAGS := -shared -static-libgcc
 Linux-armhf_LIBNAME   := libcommons-crypto.so
 Linux-armhf_COMMONS_CRYPTO_FLAGS:=
@@ -208,8 +208,8 @@ FreeBSD-x86_64_COMMONS_CRYPTO_FLAGS :=
 Windows-x86_CC           := $(CROSS_PREFIX)gcc
 Windows-x86_CXX          := $(CROSS_PREFIX)g++
 Windows-x86_STRIP        := $(CROSS_PREFIX)strip
-Windows-x86_CFLAGS       := -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -I"$(OPENSSL_HOME)/include" -Ilib/inc_win -O2 -fno-inline
-Windows-x86_CXXFLAGS     := -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -I"$(OPENSSL_HOME)/include" -Ilib/inc_win -O2 -fno-inline
+Windows-x86_CFLAGS       := -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -O2 -fno-inline
+Windows-x86_CXXFLAGS     := -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -O2 -fno-inline
 Windows-x86_LINKFLAGS    := -Wl,--kill-at -shared -static
 Windows-x86_LIBNAME      := commons-crypto.dll
 Windows-x86_COMMONS_CRYPTO_FLAGS :=
@@ -217,8 +217,8 @@ Windows-x86_COMMONS_CRYPTO_FLAGS :=
 Windows-x86_64_CC           := $(CROSS_PREFIX)gcc
 Windows-x86_64_CXX          := $(CROSS_PREFIX)g++
 Windows-x86_64_STRIP        := $(CROSS_PREFIX)strip
-Windows-x86_64_CFLAGS       := -I/openssl-1.1.1/include -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -O2 -fno-inline
-Windows-x86_64_CXXFLAGS     := -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -I"$(OPENSSL_HOME)/include" -Ilib/inc_win -O2 -fno-inline
+Windows-x86_64_CFLAGS       := -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -O2 -fno-inline
+Windows-x86_64_CXXFLAGS     := -I/usr/share/mingw-w64/include -I"$(JAVA_HOME)/include" -O2 -fno-inline
 Windows-x86_64_LINKFLAGS    := -Wl,--kill-at -shared -static
 Windows-x86_64_LIBNAME      := commons-crypto.dll
 Windows-x86_64_COMMONS-CRYPTO_FLAGS :=

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>51</version>
+    <version>52</version>
   </parent>
 
   <artifactId>commons-crypto</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,24 @@ The following provides more details on the included cryptographic software:
         </plugins>
       </build>
     </profile>
-
+    <profile>
+      <id>build</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>0.33.0</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -72,6 +72,7 @@
       <action issue="CRYPTO-141" type="fix">Errors in native code can leave Java wrappers in bad state.</action>
       <action                    type="update" dev="ggregory" due-to="Geoffrey Blake">Reset JAVA_HOME for aarch64 and ppc builds. Turn off maven-enforcer for Xenial builds #104.</action>
       <action                    type="update" dev="ggregory">Update maven-checkstyle-plugin 3.0.0 -> 3.1.1.</action>
+      <action                    type="update" dev="ggregory">Update commons-parent 51 -> 52.</action>
     </release>
 
     <release version="1.0.0" date="2016-07-22" description="

--- a/src/main/java/org/apache/commons/crypto/Crypto.java
+++ b/src/main/java/org/apache/commons/crypto/Crypto.java
@@ -22,7 +22,9 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Properties;
 
+import org.apache.commons.crypto.cipher.CryptoCipher;
 import org.apache.commons.crypto.cipher.CryptoCipherFactory;
+import org.apache.commons.crypto.random.CryptoRandom;
 import org.apache.commons.crypto.random.CryptoRandomFactory;
 
 /**
@@ -122,8 +124,9 @@ public final class Crypto {
     }
 
     /**
-     * The Main of Crypto
-     * @param args don't use the args
+     * The Main of Crypto.
+     *
+     * @param args Not used.
      * @throws Exception if getCryptoRandom or getCryptoCipher get error.
      */
     public static void main(final String args[]) throws Exception {
@@ -137,14 +140,16 @@ public final class Crypto {
             {
                 final Properties props = new Properties();
                 props.setProperty(CryptoRandomFactory.CLASSES_KEY, CryptoRandomFactory.RandomProvider.OPENSSL.getClassName());
-                CryptoRandomFactory.getCryptoRandom(props);
-                System.out.println("Random instance created OK");
+                try (CryptoRandom cryptoRandom = CryptoRandomFactory.getCryptoRandom(props)){
+                    System.out.println("Random instance created OK");
+                }
             }
             {
                 final Properties props = new Properties();
                 props.setProperty(CryptoCipherFactory.CLASSES_KEY, CryptoCipherFactory.CipherProvider.OPENSSL.getClassName());
-                CryptoCipherFactory.getCryptoCipher("AES/CTR/NoPadding", props);
-                System.out.println("Cipher instance created OK");
+                try (CryptoCipher cryptoCipher = CryptoCipherFactory.getCryptoCipher("AES/CTR/NoPadding", props)) {
+                    System.out.println("Cipher instance created OK");
+                }
             }
             System.out.println("Additional OpenSSL_version(n) details:");
             for(int j=1;j<6;j++) {

--- a/src/main/java/org/apache/commons/crypto/NativeCodeLoader.java
+++ b/src/main/java/org/apache/commons/crypto/NativeCodeLoader.java
@@ -170,7 +170,7 @@ final class NativeCodeLoader {
 
                 writer.close();
 
-                IoUtils.cleanup(reader);
+                IoUtils.closeQuietly(reader);
                 reader = null;
             }
 

--- a/src/main/java/org/apache/commons/crypto/cipher/CryptoCipherFactory.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/CryptoCipherFactory.java
@@ -128,6 +128,7 @@ public class CryptoCipherFactory {
             CipherProvider.OPENSSL.getClassName()
             .concat(",")
             .concat(CipherProvider.JCE.getClassName());
+
     /**
      * The private Constructor of {@link CryptoCipherFactory}.
      */
@@ -137,16 +138,16 @@ public class CryptoCipherFactory {
     /**
      * Gets a cipher instance for specified algorithm/mode/padding.
      *
-     * @param props  the configuration properties - uses {@link #CLASSES_KEY}
+     * @param properties  the configuration properties - uses {@link #CLASSES_KEY}
      * @param transformation  algorithm/mode/padding
      * @return CryptoCipher  the cipher  (defaults to OpenSslCipher)
      * @throws GeneralSecurityException if cipher initialize failed
      * @throws IllegalArgumentException if no classname(s) were provided
      */
-    public static CryptoCipher getCryptoCipher(final String transformation,
-                                           final Properties props) throws GeneralSecurityException {
+    public static CryptoCipher getCryptoCipher(final String transformation, final Properties properties)
+        throws GeneralSecurityException {
 
-        final List<String> names = Utils.splitClassNames(getCipherClassString(props), ",");
+        final List<String> names = Utils.splitClassNames(getCipherClassString(properties), ",");
         if (names.size() == 0) {
             throw new IllegalArgumentException("No classname(s) provided");
         }
@@ -158,7 +159,7 @@ public class CryptoCipherFactory {
             try {
                 final Class<?> cls = ReflectionUtils.getClassByName(klass);
                 cipher = ReflectionUtils.newInstance(cls.asSubclass
-                        (CryptoCipher.class), props, transformation);
+                        (CryptoCipher.class), properties, transformation);
                 if (cipher != null) {
                     break;
                 }

--- a/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCryptoRandom.java
@@ -47,9 +47,10 @@ import com.sun.jna.ptr.PointerByReference;
  *      http://en.wikipedia.org/wiki/RdRand</a>
  */
 class OpenSslJnaCryptoRandom extends Random implements CryptoRandom {
+
     private static final long serialVersionUID = -7128193502768749585L;
     private final boolean rdrandEnabled;
-    private PointerByReference rdrandEngine;
+    private transient PointerByReference rdrandEngine;
 
     /**
      * Constructs a {@link OpenSslJnaCryptoRandom}.

--- a/src/main/java/org/apache/commons/crypto/random/JavaCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/JavaCryptoRandom.java
@@ -27,6 +27,11 @@ import java.util.Random;
  */
 class JavaCryptoRandom extends Random implements CryptoRandom {
 
+    /**
+     * Generated serialVersionUID.
+     */
+    private static final long serialVersionUID = 5517475898166660050L;
+
     private SecureRandom instance;
 
     /**

--- a/src/main/java/org/apache/commons/crypto/random/OpenSslCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/OpenSslCryptoRandom.java
@@ -151,5 +151,6 @@ class OpenSslCryptoRandom extends Random implements CryptoRandom {
      */
     @Override
     public void close() {
+        // noop
     }
 }

--- a/src/main/java/org/apache/commons/crypto/random/OsCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/OsCryptoRandom.java
@@ -131,7 +131,7 @@ class OsCryptoRandom extends Random implements CryptoRandom {
     @Override
     synchronized public void close() {
         if (stream != null) {
-            IoUtils.cleanup(stream);
+            IoUtils.closeQuietly(stream);
             stream = null;
         }
     }

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
@@ -109,19 +109,19 @@ public class CryptoInputStream extends InputStream implements
      * <i>AES/CBC/PKCS5Padding</i>.
      * See the Java Cryptography Architecture Standard Algorithm Name Documentation
      * for information about standard transformation names.
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
-     * @param in the input stream.
+     * @param inputStream the input stream.
      * @param key crypto key for the cipher.
      * @param params the algorithm parameters.
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CryptoInputStream.
     public CryptoInputStream(final String transformation,
-            final Properties props, final InputStream in, final Key key,
+            final Properties properties, final InputStream inputStream, final Key key,
             final AlgorithmParameterSpec params) throws IOException {
-        this(in, Utils.getCipherInstance(transformation, props),
-                CryptoInputStream.getBufferSize(props), key, params);
+        this(inputStream, Utils.getCipherInstance(transformation, properties),
+                CryptoInputStream.getBufferSize(properties), key, params);
     }
 
     /**
@@ -131,51 +131,51 @@ public class CryptoInputStream extends InputStream implements
      * <i>AES/CBC/PKCS5Padding</i>.
      * See the Java Cryptography Architecture Standard Algorithm Name Documentation
      * for information about standard transformation names.
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
-     * @param in the ReadableByteChannel object.
+     * @param channel the ReadableByteChannel object.
      * @param key crypto key for the cipher.
      * @param params the algorithm parameters.
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CryptoInputStream.
     public CryptoInputStream(final String transformation,
-            final Properties props, final ReadableByteChannel in, final Key key,
+            final Properties properties, final ReadableByteChannel channel, final Key key,
             final AlgorithmParameterSpec params) throws IOException {
-        this(in, Utils.getCipherInstance(transformation, props), CryptoInputStream
-                .getBufferSize(props), key, params);
+        this(channel, Utils.getCipherInstance(transformation, properties), CryptoInputStream
+                .getBufferSize(properties), key, params);
     }
 
     /**
      * Constructs a {@link CryptoInputStream}.
      *
      * @param cipher the cipher instance.
-     * @param in the input stream.
+     * @param inputStream the input stream.
      * @param bufferSize the bufferSize.
      * @param key crypto key for the cipher.
      * @param params the algorithm parameters.
      * @throws IOException if an I/O error occurs.
      */
-    protected CryptoInputStream(final InputStream in, final CryptoCipher cipher,
+    protected CryptoInputStream(final InputStream inputStream, final CryptoCipher cipher,
             final int bufferSize, final Key key, final AlgorithmParameterSpec params)
             throws IOException {
-        this(new StreamInput(in, bufferSize), cipher, bufferSize, key, params);
+        this(new StreamInput(inputStream, bufferSize), cipher, bufferSize, key, params);
     }
 
     /**
      * Constructs a {@link CryptoInputStream}.
      *
-     * @param in the ReadableByteChannel instance.
+     * @param channel the ReadableByteChannel instance.
      * @param cipher the cipher instance.
      * @param bufferSize the bufferSize.
      * @param key crypto key for the cipher.
      * @param params the algorithm parameters.
      * @throws IOException if an I/O error occurs.
      */
-    protected CryptoInputStream(final ReadableByteChannel in, final CryptoCipher cipher,
+    protected CryptoInputStream(final ReadableByteChannel channel, final CryptoCipher cipher,
             final int bufferSize, final Key key, final AlgorithmParameterSpec params)
             throws IOException {
-        this(new ChannelInput(in), cipher, bufferSize, key, params);
+        this(new ChannelInput(channel), cipher, bufferSize, key, params);
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
@@ -361,6 +361,7 @@ public class CryptoInputStream extends InputStream implements
      */
     @Override
     public void mark(final int readlimit) {
+        // noop
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
@@ -138,6 +138,7 @@ public class CryptoInputStream extends InputStream implements
      * @param params the algorithm parameters.
      * @throws IOException if an I/O error occurs.
      */
+    @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CryptoInputStream.
     public CryptoInputStream(final String transformation,
             final Properties props, final ReadableByteChannel in, final Key key,
             final AlgorithmParameterSpec params) throws IOException {

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
@@ -116,6 +116,7 @@ public class CryptoInputStream extends InputStream implements
      * @param params the algorithm parameters.
      * @throws IOException if an I/O error occurs.
      */
+    @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CryptoInputStream.
     public CryptoInputStream(final String transformation,
             final Properties props, final InputStream in, final Key key,
             final AlgorithmParameterSpec params) throws IOException {
@@ -350,29 +351,6 @@ public class CryptoInputStream extends InputStream implements
         cipher.close();
         super.close();
         closed = true;
-    }
-
-    /**
-     * Overrides the {@link java.io.InputStream#mark(int)}. For
-     * {@link CryptoInputStream},we don't support the mark method.
-     *
-     * @param readlimit the maximum limit of bytes that can be read before the
-     *        mark position becomes invalid.
-     */
-    @Override
-    public void mark(final int readlimit) {
-        // noop
-    }
-
-    /**
-     * Overrides the {@link InputStream#reset()}. For {@link CryptoInputStream}
-     * ,we don't support the reset method.
-     *
-     * @throws IOException if an I/O error occurs.
-     */
-    @Override
-    public void reset() throws IOException {
-        throw new IOException("Mark/reset not supported");
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
@@ -92,19 +92,19 @@ public class CryptoOutputStream extends OutputStream implements
      * <i>AES/CBC/PKCS5Padding</i>.
      * See the Java Cryptography Architecture Standard Algorithm Name Documentation
      * for information about standard transformation names.
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
-     * @param out the output stream.
+     * @param outputStream the output stream.
      * @param key crypto key for the cipher.
      * @param params the algorithm parameters.
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CryptoOutputStream.
     public CryptoOutputStream(final String transformation,
-            final Properties props, final OutputStream out, final Key key,
+            final Properties properties, final OutputStream outputStream, final Key key,
             final AlgorithmParameterSpec params) throws IOException {
-        this(out, Utils.getCipherInstance(transformation, props),
-                CryptoInputStream.getBufferSize(props), key, params);
+        this(outputStream, Utils.getCipherInstance(transformation, properties),
+                CryptoInputStream.getBufferSize(properties), key, params);
 
     }
 
@@ -115,7 +115,7 @@ public class CryptoOutputStream extends OutputStream implements
      * <i>AES/CBC/PKCS5Padding</i>.
      * See the Java Cryptography Architecture Standard Algorithm Name Documentation
      * for information about standard transformation names.
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
      * @param out the WritableByteChannel instance.
      * @param key crypto key for the cipher.
@@ -124,27 +124,27 @@ public class CryptoOutputStream extends OutputStream implements
      */
     @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CryptoOutputStream.
     public CryptoOutputStream(final String transformation,
-            final Properties props, final WritableByteChannel out, final Key key,
+            final Properties properties, final WritableByteChannel out, final Key key,
             final AlgorithmParameterSpec params) throws IOException {
-        this(out, Utils.getCipherInstance(transformation, props), CryptoInputStream
-                .getBufferSize(props), key, params);
+        this(out, Utils.getCipherInstance(transformation, properties), CryptoInputStream
+                .getBufferSize(properties), key, params);
 
     }
 
     /**
      * Constructs a {@link CryptoOutputStream}.
      *
-     * @param out the output stream.
+     * @param outputStream the output stream.
      * @param cipher the CryptoCipher instance.
      * @param bufferSize the bufferSize.
      * @param key crypto key for the cipher.
      * @param params the algorithm parameters.
      * @throws IOException if an I/O error occurs.
      */
-    protected CryptoOutputStream(final OutputStream out, final CryptoCipher cipher,
+    protected CryptoOutputStream(final OutputStream outputStream, final CryptoCipher cipher,
             final int bufferSize, final Key key, final AlgorithmParameterSpec params)
             throws IOException {
-        this(new StreamOutput(out, bufferSize), cipher, bufferSize, key, params);
+        this(new StreamOutput(outputStream, bufferSize), cipher, bufferSize, key, params);
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoOutputStream.java
@@ -99,7 +99,7 @@ public class CryptoOutputStream extends OutputStream implements
      * @param params the algorithm parameters.
      * @throws IOException if an I/O error occurs.
      */
-
+    @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CryptoOutputStream.
     public CryptoOutputStream(final String transformation,
             final Properties props, final OutputStream out, final Key key,
             final AlgorithmParameterSpec params) throws IOException {
@@ -122,6 +122,7 @@ public class CryptoOutputStream extends OutputStream implements
      * @param params the algorithm parameters.
      * @throws IOException if an I/O error occurs.
      */
+    @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CryptoOutputStream.
     public CryptoOutputStream(final String transformation,
             final Properties props, final WritableByteChannel out, final Key key,
             final AlgorithmParameterSpec params) throws IOException {

--- a/src/main/java/org/apache/commons/crypto/stream/CtrCryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CtrCryptoInputStream.java
@@ -167,6 +167,7 @@ public class CtrCryptoInputStream extends CryptoInputStream {
      * @param streamOffset the start offset in the stream.
      * @throws IOException if an I/O error occurs.
      */
+    @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CtrCryptoInputStream.
     public CtrCryptoInputStream(final Properties props, final InputStream in, final byte[] key,
             final byte[] iv, final long streamOffset) throws IOException {
         this(in, Utils.getCipherInstance(
@@ -185,6 +186,7 @@ public class CtrCryptoInputStream extends CryptoInputStream {
      * @param streamOffset the start offset in the stream.
      * @throws IOException if an I/O error occurs.
      */
+    @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CtrCryptoInputStream.
     public CtrCryptoInputStream(final Properties props, final ReadableByteChannel in,
             final byte[] key, final byte[] iv, final long streamOffset) throws IOException {
         this(in, Utils.getCipherInstance(

--- a/src/main/java/org/apache/commons/crypto/stream/CtrCryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CtrCryptoInputStream.java
@@ -84,61 +84,61 @@ public class CtrCryptoInputStream extends CryptoInputStream {
     /**
      * Constructs a {@link CtrCryptoInputStream}.
      *
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
-     * @param in the input stream.
+     * @param inputStream the input stream.
      * @param key crypto key for the cipher.
      * @param iv Initialization vector for the cipher.
      * @throws IOException if an I/O error occurs.
      */
-    public CtrCryptoInputStream(final Properties props, final InputStream in, final byte[] key,
+    public CtrCryptoInputStream(final Properties properties, final InputStream inputStream, final byte[] key,
             final byte[] iv) throws IOException {
-        this(props, in, key, iv, 0);
+        this(properties, inputStream, key, iv, 0);
     }
 
     /**
      * Constructs a {@link CtrCryptoInputStream}.
      *
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
-     * @param in the ReadableByteChannel instance.
+     * @param channel the ReadableByteChannel instance.
      * @param key crypto key for the cipher.
      * @param iv Initialization vector for the cipher.
      * @throws IOException if an I/O error occurs.
      */
-    public CtrCryptoInputStream(final Properties props, final ReadableByteChannel in,
+    public CtrCryptoInputStream(final Properties properties, final ReadableByteChannel channel,
             final byte[] key, final byte[] iv) throws IOException {
-        this(props, in, key, iv, 0);
+        this(properties, channel, key, iv, 0);
     }
 
     /**
      * Constructs a {@link CtrCryptoInputStream}.
      *
-     * @param in the input stream.
+     * @param inputStream the input stream.
      * @param cipher the CryptoCipher instance.
      * @param bufferSize the bufferSize.
      * @param key crypto key for the cipher.
      * @param iv Initialization vector for the cipher.
      * @throws IOException if an I/O error occurs.
      */
-    protected CtrCryptoInputStream(final InputStream in, final CryptoCipher cipher,
+    protected CtrCryptoInputStream(final InputStream inputStream, final CryptoCipher cipher,
             final int bufferSize, final byte[] key, final byte[] iv) throws IOException {
-        this(in, cipher, bufferSize, key, iv, 0);
+        this(inputStream, cipher, bufferSize, key, iv, 0);
     }
 
     /**
      * Constructs a {@link CtrCryptoInputStream}.
      *
-     * @param in the ReadableByteChannel instance.
+     * @param channel the ReadableByteChannel instance.
      * @param cipher the cipher instance.
      * @param bufferSize the bufferSize.
      * @param key crypto key for the cipher.
      * @param iv Initialization vector for the cipher.
      * @throws IOException if an I/O error occurs.
      */
-    protected CtrCryptoInputStream(final ReadableByteChannel in, final CryptoCipher cipher,
+    protected CtrCryptoInputStream(final ReadableByteChannel channel, final CryptoCipher cipher,
             final int bufferSize, final byte[] key, final byte[] iv) throws IOException {
-        this(in, cipher, bufferSize, key, iv, 0);
+        this(channel, cipher, bufferSize, key, iv, 0);
     }
 
     /**
@@ -159,26 +159,26 @@ public class CtrCryptoInputStream extends CryptoInputStream {
     /**
      * Constructs a {@link CtrCryptoInputStream}.
      *
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
-     * @param in the InputStream instance.
+     * @param inputStream the InputStream instance.
      * @param key crypto key for the cipher.
      * @param iv Initialization vector for the cipher.
      * @param streamOffset the start offset in the stream.
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CtrCryptoInputStream.
-    public CtrCryptoInputStream(final Properties props, final InputStream in, final byte[] key,
+    public CtrCryptoInputStream(final Properties properties, final InputStream inputStream, final byte[] key,
             final byte[] iv, final long streamOffset) throws IOException {
-        this(in, Utils.getCipherInstance(
-                "AES/CTR/NoPadding", props),
-                CryptoInputStream.getBufferSize(props), key, iv, streamOffset);
+        this(inputStream, Utils.getCipherInstance(
+                "AES/CTR/NoPadding", properties),
+                CryptoInputStream.getBufferSize(properties), key, iv, streamOffset);
     }
 
     /**
      * Constructs a {@link CtrCryptoInputStream}.
      *
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
      * @param in the ReadableByteChannel instance.
      * @param key crypto key for the cipher.
@@ -187,17 +187,17 @@ public class CtrCryptoInputStream extends CryptoInputStream {
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CtrCryptoInputStream.
-    public CtrCryptoInputStream(final Properties props, final ReadableByteChannel in,
+    public CtrCryptoInputStream(final Properties properties, final ReadableByteChannel in,
             final byte[] key, final byte[] iv, final long streamOffset) throws IOException {
         this(in, Utils.getCipherInstance(
-                "AES/CTR/NoPadding", props),
-                CryptoInputStream.getBufferSize(props), key, iv, streamOffset);
+                "AES/CTR/NoPadding", properties),
+                CryptoInputStream.getBufferSize(properties), key, iv, streamOffset);
     }
 
     /**
      * Constructs a {@link CtrCryptoInputStream}.
      *
-     * @param in the InputStream instance.
+     * @param inputStream the InputStream instance.
      * @param cipher the CryptoCipher instance.
      * @param bufferSize the bufferSize.
      * @param key crypto key for the cipher.
@@ -205,17 +205,17 @@ public class CtrCryptoInputStream extends CryptoInputStream {
      * @param streamOffset the start offset in the stream.
      * @throws IOException if an I/O error occurs.
      */
-    protected CtrCryptoInputStream(final InputStream in, final CryptoCipher cipher,
+    protected CtrCryptoInputStream(final InputStream inputStream, final CryptoCipher cipher,
             final int bufferSize, final byte[] key, final byte[] iv, final long streamOffset)
             throws IOException {
-        this(new StreamInput(in, bufferSize), cipher, bufferSize, key, iv,
+        this(new StreamInput(inputStream, bufferSize), cipher, bufferSize, key, iv,
                 streamOffset);
     }
 
     /**
      * Constructs a {@link CtrCryptoInputStream}.
      *
-     * @param in the ReadableByteChannel instance.
+     * @param channel the ReadableByteChannel instance.
      * @param cipher the CryptoCipher instance.
      * @param bufferSize the bufferSize.
      * @param key crypto key for the cipher.
@@ -223,10 +223,10 @@ public class CtrCryptoInputStream extends CryptoInputStream {
      * @param streamOffset the start offset in the stream.
      * @throws IOException if an I/O error occurs.
      */
-    protected CtrCryptoInputStream(final ReadableByteChannel in, final CryptoCipher cipher,
+    protected CtrCryptoInputStream(final ReadableByteChannel channel, final CryptoCipher cipher,
             final int bufferSize, final byte[] key, final byte[] iv, final long streamOffset)
             throws IOException {
-        this(new ChannelInput(in), cipher, bufferSize, key, iv, streamOffset);
+        this(new ChannelInput(channel), cipher, bufferSize, key, iv, streamOffset);
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/stream/CtrCryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CtrCryptoOutputStream.java
@@ -164,45 +164,45 @@ public class CtrCryptoOutputStream extends CryptoOutputStream {
     /**
      * Constructs a {@link CtrCryptoOutputStream}.
      *
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
-     * @param out the output stream.
+     * @param outputStream the output stream.
      * @param key crypto key for the cipher.
      * @param iv Initialization vector for the cipher.
      * @param streamOffset the start offset in the data.
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CtrCryptoOutputStream.
-    public CtrCryptoOutputStream(final Properties props, final OutputStream out,
+    public CtrCryptoOutputStream(final Properties properties, final OutputStream outputStream,
             final byte[] key, final byte[] iv, final long streamOffset) throws IOException {
-        this(out, Utils.getCipherInstance(
-                "AES/CTR/NoPadding", props),
-                CryptoInputStream.getBufferSize(props), key, iv, streamOffset);
+        this(outputStream, Utils.getCipherInstance(
+                "AES/CTR/NoPadding", properties),
+                CryptoInputStream.getBufferSize(properties), key, iv, streamOffset);
     }
 
     /**
      * Constructs a {@link CtrCryptoOutputStream}.
      *
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
-     * @param out the WritableByteChannel instance.
+     * @param channel the WritableByteChannel instance.
      * @param key crypto key for the cipher.
      * @param iv Initialization vector for the cipher.
      * @param streamOffset the start offset in the data.
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CtrCryptoOutputStream.
-    public CtrCryptoOutputStream(final Properties props, final WritableByteChannel out,
+    public CtrCryptoOutputStream(final Properties properties, final WritableByteChannel channel,
             final byte[] key, final byte[] iv, final long streamOffset) throws IOException {
-        this(out, Utils.getCipherInstance(
-                "AES/CTR/NoPadding", props),
-                CryptoInputStream.getBufferSize(props), key, iv, streamOffset);
+        this(channel, Utils.getCipherInstance(
+                "AES/CTR/NoPadding", properties),
+                CryptoInputStream.getBufferSize(properties), key, iv, streamOffset);
     }
 
     /**
      * Constructs a {@link CtrCryptoOutputStream}.
      *
-     * @param out the output stream.
+     * @param outputStream the output stream.
      * @param cipher the CryptoCipher instance.
      * @param bufferSize the bufferSize.
      * @param key crypto key for the cipher.
@@ -210,10 +210,10 @@ public class CtrCryptoOutputStream extends CryptoOutputStream {
      * @param streamOffset the start offset in the data.
      * @throws IOException if an I/O error occurs.
      */
-    protected CtrCryptoOutputStream(final OutputStream out, final CryptoCipher cipher,
+    protected CtrCryptoOutputStream(final OutputStream outputStream, final CryptoCipher cipher,
             final int bufferSize, final byte[] key, final byte[] iv, final long streamOffset)
             throws IOException {
-        this(new StreamOutput(out, bufferSize), cipher, bufferSize, key, iv,
+        this(new StreamOutput(outputStream, bufferSize), cipher, bufferSize, key, iv,
                 streamOffset);
     }
 

--- a/src/main/java/org/apache/commons/crypto/stream/CtrCryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CtrCryptoOutputStream.java
@@ -172,6 +172,7 @@ public class CtrCryptoOutputStream extends CryptoOutputStream {
      * @param streamOffset the start offset in the data.
      * @throws IOException if an I/O error occurs.
      */
+    @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CtrCryptoOutputStream.
     public CtrCryptoOutputStream(final Properties props, final OutputStream out,
             final byte[] key, final byte[] iv, final long streamOffset) throws IOException {
         this(out, Utils.getCipherInstance(
@@ -190,6 +191,7 @@ public class CtrCryptoOutputStream extends CryptoOutputStream {
      * @param streamOffset the start offset in the data.
      * @throws IOException if an I/O error occurs.
      */
+    @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CtrCryptoOutputStream.
     public CtrCryptoOutputStream(final Properties props, final WritableByteChannel out,
             final byte[] key, final byte[] iv, final long streamOffset) throws IOException {
         this(out, Utils.getCipherInstance(

--- a/src/main/java/org/apache/commons/crypto/stream/PositionedCryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/PositionedCryptoInputStream.java
@@ -71,6 +71,7 @@ public class PositionedCryptoInputStream extends CtrCryptoInputStream {
      * @param streamOffset the start offset in the data.
      * @throws IOException if an I/O error occurs.
      */
+    @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by PositionedCryptoInputStream.
     public PositionedCryptoInputStream(final Properties props, final Input in, final byte[] key,
             final byte[] iv, final long streamOffset) throws IOException {
         this(props, in, Utils.getCipherInstance("AES/CTR/NoPadding", props),

--- a/src/main/java/org/apache/commons/crypto/stream/PositionedCryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/PositionedCryptoInputStream.java
@@ -58,12 +58,12 @@ public class PositionedCryptoInputStream extends CtrCryptoInputStream {
     /**
      * properties for constructing a CryptoCipher
      */
-    private final Properties props;
+    private final Properties properties;
 
     /**
      * Constructs a {@link PositionedCryptoInputStream}.
      *
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
      * @param in the input data.
      * @param key crypto key for the cipher.
@@ -72,16 +72,16 @@ public class PositionedCryptoInputStream extends CtrCryptoInputStream {
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by PositionedCryptoInputStream.
-    public PositionedCryptoInputStream(final Properties props, final Input in, final byte[] key,
+    public PositionedCryptoInputStream(final Properties properties, final Input in, final byte[] key,
             final byte[] iv, final long streamOffset) throws IOException {
-        this(props, in, Utils.getCipherInstance("AES/CTR/NoPadding", props),
-                CryptoInputStream.getBufferSize(props), key, iv, streamOffset);
+        this(properties, in, Utils.getCipherInstance("AES/CTR/NoPadding", properties),
+                CryptoInputStream.getBufferSize(properties), key, iv, streamOffset);
     }
 
     /**
      * Constructs a {@link PositionedCryptoInputStream}.
      *
-     * @param props the props of stream
+     * @param properties the properties of stream
      * @param input the input data.
      * @param cipher the CryptoCipher instance.
      * @param bufferSize the bufferSize.
@@ -90,11 +90,11 @@ public class PositionedCryptoInputStream extends CtrCryptoInputStream {
      * @param streamOffset the start offset in the data.
      * @throws IOException if an I/O error occurs.
      */
-    protected PositionedCryptoInputStream(final Properties props, final Input input, final CryptoCipher cipher,
+    protected PositionedCryptoInputStream(final Properties properties, final Input input, final CryptoCipher cipher,
             final int bufferSize, final byte[] key, final byte[] iv, final long streamOffset)
             throws IOException {
         super(input, cipher, bufferSize, key, iv, streamOffset);
-        this.props = props;
+        this.properties = properties;
     }
 
     /**
@@ -321,7 +321,7 @@ public class PositionedCryptoInputStream extends CtrCryptoInputStream {
         if (state == null) {
             CryptoCipher cryptoCipher;
             try {
-                cryptoCipher = CryptoCipherFactory.getCryptoCipher("AES/CTR/NoPadding", props);
+                cryptoCipher = CryptoCipherFactory.getCryptoCipher("AES/CTR/NoPadding", properties);
             } catch (final GeneralSecurityException e) {
                 throw new IOException(e);
             }
@@ -392,7 +392,8 @@ public class PositionedCryptoInputStream extends CtrCryptoInputStream {
         }
     }
 
-    private class CipherState {
+    private static class CipherState {
+
         private final CryptoCipher cryptoCipher;
         private boolean reset;
 

--- a/src/main/java/org/apache/commons/crypto/stream/output/ChannelOutput.java
+++ b/src/main/java/org/apache/commons/crypto/stream/output/ChannelOutput.java
@@ -64,6 +64,7 @@ public class ChannelOutput implements Output {
      */
     @Override
     public void flush() throws IOException {
+        // noop
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/utils/IoUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/IoUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.commons.crypto.utils;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -86,13 +87,25 @@ public final class IoUtils {
      *
      * @param closeables the objects to close.
      */
-    public static void cleanup(final java.io.Closeable... closeables) {
-        for (final java.io.Closeable c : closeables) {
-            if (c != null) {
-                try {
-                    c.close();
-                } catch (final IOException e) { // NOPMD
-                }
+    public static void cleanup(final Closeable... closeables) {
+        if (closeables != null) {
+            for (final Closeable c : closeables) {
+                closeQuietly(c);
+            }
+        }
+    }
+
+    /**
+     * Closes the given {@link Closeable} quietly by ignoring IOException.
+     *
+     * @param closeable The resource to close.
+     * @since 1.1.0
+     */
+    public static void closeQuietly(final Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (final IOException e) { // NOPMD
             }
         }
     }

--- a/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
@@ -57,6 +57,7 @@ public final class ReflectionUtils {
      * getClassByName. {@link #getClassByNameOrNull(String)}.
      */
     private static abstract class NegativeCacheSentinel {
+        // noop
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/utils/Utils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/Utils.java
@@ -113,7 +113,7 @@ public final class Utils {
      * Helper method to create a CryptoCipher instance and throws only
      * IOException.
      *
-     * @param props The {@code Properties} class represents a set of
+     * @param properties The {@code Properties} class represents a set of
      *        properties.
      * @param transformation the name of the transformation, e.g.,
      * <i>AES/CBC/PKCS5Padding</i>.
@@ -123,10 +123,10 @@ public final class Utils {
      * @throws IOException if an I/O error occurs.
      */
     public static CryptoCipher getCipherInstance(
-            final String transformation, final Properties props)
+            final String transformation, final Properties properties)
             throws IOException {
         try {
-            return CryptoCipherFactory.getCryptoCipher(transformation, props);
+            return CryptoCipherFactory.getCryptoCipher(transformation, properties);
         } catch (final GeneralSecurityException e) {
             throw new IOException(e);
         }

--- a/src/main/java/org/apache/commons/crypto/utils/Utils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/Utils.java
@@ -62,16 +62,16 @@ public final class Utils {
         // default to system
         final Properties defaultedProps = new Properties(System.getProperties());
         try {
-            final InputStream is = Thread.currentThread().getContextClassLoader()
-                    .getResourceAsStream(SYSTEM_PROPERTIES_FILE);
-
-            if (is == null) {
-                return defaultedProps; // no configuration file is found
-            }
-            // Load property file
             final Properties fileProps = new Properties();
-            fileProps.load(is);
-            is.close();
+            try (final InputStream is = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream(SYSTEM_PROPERTIES_FILE)) {
+
+                if (is == null) {
+                    return defaultedProps; // no configuration file is found
+                }
+                // Load property file
+                fileProps.load(is);
+            }
             final Enumeration<?> names = fileProps.propertyNames();
             while (names.hasMoreElements()) {
                 final String name = (String) names.nextElement();

--- a/src/test/java/org/apache/commons/crypto/cipher/GcmCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/GcmCipherTest.java
@@ -198,7 +198,7 @@ public class GcmCipherTest {
 
         final Random r = new Random();
         final int textLength = r.nextInt(1024*1024);
-        final int ivLength = r.nextInt(60);
+        final int ivLength = r.nextInt(59) + 1;
         final int keyLength = 16;
         final int tagLength = 128;  // bits
         final int aadLength = r.nextInt(128);

--- a/src/test/java/org/apache/commons/crypto/stream/AbstractCipherStreamTest.java
+++ b/src/test/java/org/apache/commons/crypto/stream/AbstractCipherStreamTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractCipherStreamTest {
     public abstract void setUp() throws IOException;
 
     @Before
-    public void before() throws IOException {
+    public void before() throws Exception {
         final Random random = new SecureRandom();
         random.nextBytes(data);
         random.nextBytes(key);
@@ -131,7 +131,8 @@ public abstract class AbstractCipherStreamTest {
                 return; // Skip this test if no JNI
             }
         }
-        try (InputStream in = getCryptoInputStream(
+        try (@SuppressWarnings("resource") // The CryptoCipher returned by getCipherInstance() is closed by CryptoInputStream.
+        InputStream in = newCryptoInputStream(
                 new ByteArrayInputStream(encData), getCipher(cipherClass),
                 defaultBufferSize, iv, withChannel)) {
             final byte[] result = new byte[dataLen];
@@ -171,139 +172,139 @@ public abstract class AbstractCipherStreamTest {
         }
         ByteBuffer buf = ByteBuffer.allocate(dataLen + 100);
         // Default buffer size, initial buffer position is 0
-        try (InputStream in = getCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
+        try (InputStream in = newCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
             defaultBufferSize, iv, withChannel)) {
             byteBufferReadCheck(in, buf, 0);
         }
 
         // Default buffer size, initial buffer position is not 0
-        try (InputStream in = getCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
+        try (InputStream in = newCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
             defaultBufferSize, iv, withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 11);
         }
 
         // Small buffer size, initial buffer position is 0
-        try (InputStream in = getCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
+        try (InputStream in = newCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
             smallBufferSize, iv, withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 0);
         }
 
         // Small buffer size, initial buffer position is not 0
-        try (InputStream in = getCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
+        try (InputStream in = newCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
             smallBufferSize, iv, withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 11);
         }
 
         // Direct buffer, default buffer size, initial buffer position is 0
-        try (InputStream in = getCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
+        try (InputStream in = newCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
             defaultBufferSize, iv, withChannel)) {
             buf = ByteBuffer.allocateDirect(dataLen + 100);
             byteBufferReadCheck(in, buf, 0);
         }
 
         // Direct buffer, default buffer size, initial buffer position is not 0
-        try (InputStream in = getCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
+        try (InputStream in = newCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
             defaultBufferSize, iv, withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 11);
         }
 
         // Direct buffer, small buffer size, initial buffer position is 0
-        try (InputStream in = getCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
+        try (InputStream in = newCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
             smallBufferSize, iv, withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 0);
         }
 
         // Direct buffer, small buffer size, initial buffer position is not 0
-        try (InputStream in = getCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
+        try (InputStream in = newCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
             smallBufferSize, iv, withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 11);
         }
 
         // Direct buffer, small buffer size, initial buffer position is 0, final read
-        try (InputStream in = getCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
+        try (InputStream in = newCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
             smallBufferSize, iv, withChannel)) {
             buf.clear();
             byteBufferFinalReadCheck(in, buf, 0);
         }
 
         // Default buffer size, initial buffer position is 0, insufficient dest buffer length
-        try (InputStream in = getCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
+        try (InputStream in = newCryptoInputStream(new ByteArrayInputStream(encData), getCipher(cipherClass),
             defaultBufferSize, iv, withChannel)) {
             buf = ByteBuffer.allocate(100);
             byteBufferReadCheck(in, buf, 0);
         }
 
         // Default buffer size, initial buffer position is 0
-        try (InputStream in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
+        try (InputStream in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
             new IvParameterSpec(iv), withChannel)) {
             buf = ByteBuffer.allocate(dataLen + 100);
             byteBufferReadCheck(in, buf, 0);
         }
 
         // Default buffer size, initial buffer position is not 0
-        try (InputStream in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
+        try (InputStream in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
             new IvParameterSpec(iv), withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 11);
         }
 
         // Small buffer size, initial buffer position is 0
-        try (InputStream in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
+        try (InputStream in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
             new IvParameterSpec(iv), withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 0);
         }
 
         // Small buffer size, initial buffer position is not 0
-        try (InputStream in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
+        try (InputStream in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
             new IvParameterSpec(iv), withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 11);
         }
 
         // Direct buffer, default buffer size, initial buffer position is 0
-        try (InputStream in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
+        try (InputStream in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
             new IvParameterSpec(iv), withChannel)) {
             buf = ByteBuffer.allocateDirect(dataLen + 100);
             byteBufferReadCheck(in, buf, 0);
         }
 
         // Direct buffer, default buffer size, initial buffer position is not 0
-        try (InputStream in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
+        try (InputStream in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
             new IvParameterSpec(iv), withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 11);
         }
 
         // Direct buffer, small buffer size, initial buffer position is 0
-        try (InputStream in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
+        try (InputStream in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
             new IvParameterSpec(iv), withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 0);
         }
 
         // Direct buffer, small buffer size, initial buffer position is not 0
-        try (InputStream in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
+        try (InputStream in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
             new IvParameterSpec(iv), withChannel)) {
             buf.clear();
             byteBufferReadCheck(in, buf, 11);
         }
 
         // Direct buffer, default buffer size, initial buffer position is 0, final read
-        try (InputStream in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
+        try (InputStream in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
             new IvParameterSpec(iv), withChannel)) {
             buf.clear();
             byteBufferFinalReadCheck(in, buf, 0);
         }
 
         // Default buffer size, initial buffer position is 0, insufficient dest buffer length
-        try (InputStream in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
+        try (InputStream in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData), key,
             new IvParameterSpec(iv), withChannel)) {
             buf = ByteBuffer.allocate(100);
             byteBufferReadCheck(in, buf, 0);
@@ -319,20 +320,20 @@ public abstract class AbstractCipherStreamTest {
             }
         }
         baos.reset();
-        CryptoOutputStream out = getCryptoOutputStream(baos,
+        CryptoOutputStream out = newCryptoOutputStream(baos,
                 getCipher(cipherClass), defaultBufferSize, iv, withChannel);
         doByteBufferWrite(out, withChannel);
 
         baos.reset();
         final CryptoCipher cipher = getCipher(cipherClass);
         final String transformation = cipher.getAlgorithm();
-        out = getCryptoOutputStream(transformation, props, baos, key,
+        out = newCryptoOutputStream(transformation, props, baos, key,
                 new IvParameterSpec(iv), withChannel);
         doByteBufferWrite(out, withChannel);
         out.write(1);
         Assert.assertTrue(out.isOpen());
 
-        out = getCryptoOutputStream(transformation, props, baos, key,
+        out = newCryptoOutputStream(transformation, props, baos, key,
                 new IvParameterSpec(iv), withChannel);
         out.close();
         Assert.assertTrue(!out.isOpen());
@@ -351,9 +352,8 @@ public abstract class AbstractCipherStreamTest {
 
         // Test InvalidAlgorithmParameters
         try {
-        	in = getCryptoInputStream(transformation, props, new ByteArrayInputStream(encData),
-                    new SecretKeySpec(key, "AES"), new GCMParameterSpec(0, new byte[0]),
-                    withChannel);
+            in = newCryptoInputStream(transformation, props, new ByteArrayInputStream(encData),
+                new SecretKeySpec(key, "AES"), new GCMParameterSpec(0, new byte[0]), withChannel);
             Assert.fail("Expected IOException.");
         } catch (final IOException ex) {
             Assert.assertEquals(ex.getMessage(),"Illegal parameters");
@@ -361,7 +361,7 @@ public abstract class AbstractCipherStreamTest {
 
         // Test InvalidAlgorithmParameters
         try {
-            out = getCryptoOutputStream(transformation, props, baos,
+            out = newCryptoOutputStream(transformation, props, baos,
                     new SecretKeySpec(key, "AES"), new GCMParameterSpec(0,
                     new byte[0]), withChannel);
             Assert.fail("Expected IOException.");
@@ -371,7 +371,7 @@ public abstract class AbstractCipherStreamTest {
 
         // Test Invalid Key
         try {
-            in = getCryptoInputStream(transformation,props, new ByteArrayInputStream(encData),
+            in = newCryptoInputStream(transformation,props, new ByteArrayInputStream(encData),
                     new SecretKeySpec(new byte[10], "AES"), new IvParameterSpec(iv), withChannel);
             Assert.fail("Expected IOException for Invalid Key");
         } catch (final IOException ex) {
@@ -380,7 +380,7 @@ public abstract class AbstractCipherStreamTest {
 
         // Test Invalid Key
         try {
-            out = getCryptoOutputStream(transformation, props, baos, new byte[10],
+            out = newCryptoOutputStream(transformation, props, baos, new byte[10],
                     new IvParameterSpec(iv), withChannel);
             Assert.fail("Expected IOException for Invalid Key");
         } catch (final IOException ex) {
@@ -389,7 +389,7 @@ public abstract class AbstractCipherStreamTest {
 
         // Test reading a closed stream.
         try {
-            in = getCryptoInputStream(new ByteArrayInputStream(encData),
+            in = newCryptoInputStream(new ByteArrayInputStream(encData),
                     getCipher(cipherClass), defaultBufferSize, iv, withChannel);
             in.close();
             in.read(); // Throw exception.
@@ -406,7 +406,7 @@ public abstract class AbstractCipherStreamTest {
 
         // Test checking a closed stream.
         try {
-            out = getCryptoOutputStream(transformation, props, baos, key, new IvParameterSpec(iv),
+            out = newCryptoOutputStream(transformation, props, baos, key, new IvParameterSpec(iv),
                     withChannel);
             out.close();
             ((CryptoOutputStream)out).checkStream(); // Throw exception.
@@ -432,21 +432,21 @@ public abstract class AbstractCipherStreamTest {
 
         // Test unsupported operation handling.
         try {
-            in = getCryptoInputStream(new ByteArrayInputStream(encData),
+            in = newCryptoInputStream(new ByteArrayInputStream(encData),
                     getCipher(cipherClass), defaultBufferSize, iv, false);
             in.mark(0);
             assertEquals(false, in.markSupported());
             in.reset();
             Assert.fail("Expected IOException.");
         } catch (final IOException ex) {
-            Assert.assertTrue(ex.getMessage().equals("Mark/reset not supported"));
+            Assert.assertTrue(ex.getMessage().equals("mark/reset not supported"));
         } finally {
             in.close();
         }
     }
 
     protected void doFieldGetterTest(final String cipherClass, final ByteArrayOutputStream baos,
-            final boolean withChannel) throws Exception {
+        final boolean withChannel) throws Exception {
         if (AbstractCipherTest.OPENSSL_CIPHER_CLASSNAME.equals(cipherClass)) {
             if (!Crypto.isNativeCodeLoaded()) {
                 return; // Skip this test if no JNI
@@ -455,7 +455,7 @@ public abstract class AbstractCipherStreamTest {
 
         final CryptoCipher cipher = getCipher(cipherClass);
 
-        final CryptoInputStream in = getCryptoInputStream(
+        final CryptoInputStream in = newCryptoInputStream(
                 new ByteArrayInputStream(encData), cipher, defaultBufferSize,
                 iv, withChannel);
 
@@ -470,7 +470,7 @@ public abstract class AbstractCipherStreamTest {
         Assert.assertEquals(in.getParams().getClass(), IvParameterSpec.class);
         Assert.assertNotNull(in.getInput());
 
-        final CryptoOutputStream out = getCryptoOutputStream(baos, getCipher(cipherClass),
+        final CryptoOutputStream out = newCryptoOutputStream(baos, getCipher(cipherClass),
                 defaultBufferSize, iv, withChannel);
 
         Assert.assertEquals(out.getOutBuffer().capacity(), defaultBufferSize + cipher.getBlockSize());
@@ -565,7 +565,7 @@ public abstract class AbstractCipherStreamTest {
 
         out.flush();
 
-        try (InputStream in = getCryptoInputStream(
+        try (InputStream in = newCryptoInputStream(
                 new ByteArrayInputStream(encData), out.getCipher(),
                 defaultBufferSize, iv, withChannel)) {
             buf = ByteBuffer.allocate(dataLen + 100);
@@ -573,7 +573,7 @@ public abstract class AbstractCipherStreamTest {
         }
     }
 
-    protected CryptoInputStream getCryptoInputStream(final ByteArrayInputStream bais,
+    protected CryptoInputStream newCryptoInputStream(final ByteArrayInputStream bais,
             final CryptoCipher cipher, final int bufferSize, final byte[] iv, final boolean withChannel)
             throws IOException {
         if (withChannel) {
@@ -585,7 +585,7 @@ public abstract class AbstractCipherStreamTest {
                 new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
     }
 
-    protected CryptoInputStream getCryptoInputStream(final String transformation, final Properties props,
+    protected CryptoInputStream newCryptoInputStream(final String transformation, final Properties props,
     	    final ByteArrayInputStream bais, final byte[] key, final AlgorithmParameterSpec params,
     	    final boolean withChannel) throws IOException {
         if (withChannel) {
@@ -594,7 +594,7 @@ public abstract class AbstractCipherStreamTest {
         return new CryptoInputStream(transformation, props, bais, new SecretKeySpec(key, "AES"), params);
     }
 
-    protected CryptoInputStream getCryptoInputStream(final String transformation,
+    protected CryptoInputStream newCryptoInputStream(final String transformation,
             final Properties props, final ByteArrayInputStream bais, final Key key,
             final AlgorithmParameterSpec params, final boolean withChannel) throws IOException {
         if (withChannel) {
@@ -603,7 +603,7 @@ public abstract class AbstractCipherStreamTest {
         return new CryptoInputStream(transformation, props, bais, key, params);
     }
 
-    protected CryptoOutputStream getCryptoOutputStream(
+    protected CryptoOutputStream newCryptoOutputStream(
             final ByteArrayOutputStream baos, final CryptoCipher cipher, final int bufferSize,
             final byte[] iv, final boolean withChannel) throws IOException {
         if (withChannel) {
@@ -615,7 +615,7 @@ public abstract class AbstractCipherStreamTest {
                 new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
     }
 
-    protected CryptoOutputStream getCryptoOutputStream(final String transformation,
+    protected CryptoOutputStream newCryptoOutputStream(final String transformation,
             final Properties props, final ByteArrayOutputStream baos, final byte[] key,
             final AlgorithmParameterSpec param, final boolean withChannel) throws IOException {
         if (withChannel) {
@@ -626,7 +626,7 @@ public abstract class AbstractCipherStreamTest {
                 param);
     }
 
-    protected CryptoOutputStream getCryptoOutputStream(final String transformation,
+    protected CryptoOutputStream newCryptoOutputStream(final String transformation,
             final Properties props, final ByteArrayOutputStream baos, final Key key,
             final AlgorithmParameterSpec params, final boolean withChannel) throws IOException {
         if (withChannel) {
@@ -706,7 +706,7 @@ public abstract class AbstractCipherStreamTest {
 
         // Encrypt data
         final ByteArrayOutputStream encryptedData = new ByteArrayOutputStream();
-        try (CryptoOutputStream out = getCryptoOutputStream(encryptedData,
+        try (CryptoOutputStream out = newCryptoOutputStream(encryptedData,
                 encCipher, defaultBufferSize, iv, false)) {
             out.write(originalData, 0, originalData.length);
             out.flush();
@@ -716,7 +716,7 @@ public abstract class AbstractCipherStreamTest {
         final CryptoCipher decCipher = getCipher(decCipherClass);
 
         // Decrypt data
-        CryptoInputStream in = getCryptoInputStream(new ByteArrayInputStream(
+        CryptoInputStream in = newCryptoInputStream(new ByteArrayInputStream(
                 encryptedData.toByteArray()), decCipher, defaultBufferSize, iv,
                 false);
 
@@ -736,7 +736,7 @@ public abstract class AbstractCipherStreamTest {
                 originalData, decryptedData);
 
         // Decrypt data byte-at-a-time
-        in = getCryptoInputStream(
+        in = newCryptoInputStream(
                 new ByteArrayInputStream(encryptedData.toByteArray()),
                 decCipher, defaultBufferSize, iv, false);
 
@@ -774,7 +774,7 @@ public abstract class AbstractCipherStreamTest {
 
         // Encrypt data
         final ByteArrayOutputStream encryptedData = new ByteArrayOutputStream();
-        try (CryptoOutputStream out = getCryptoOutputStream(encryptedData,
+        try (CryptoOutputStream out = newCryptoOutputStream(encryptedData,
                 encCipher, defaultBufferSize, iv, true)) {
             out.write(originalData, 0, originalData.length);
             out.flush();
@@ -784,7 +784,7 @@ public abstract class AbstractCipherStreamTest {
         final CryptoCipher decCipher = getCipher(decCipherClass);
 
         // Decrypt data
-        CryptoInputStream in = getCryptoInputStream(new ByteArrayInputStream(
+        CryptoInputStream in = newCryptoInputStream(new ByteArrayInputStream(
                 encryptedData.toByteArray()), decCipher, defaultBufferSize, iv,
                 true);
 
@@ -804,7 +804,7 @@ public abstract class AbstractCipherStreamTest {
                 originalData, decryptedData);
 
         // Decrypt data byte-at-a-time
-        in = getCryptoInputStream(
+        in = newCryptoInputStream(
                 new ByteArrayInputStream(encryptedData.toByteArray()),
                 decCipher, defaultBufferSize, iv, true);
 

--- a/src/test/java/org/apache/commons/crypto/stream/CtrCryptoStreamTest.java
+++ b/src/test/java/org/apache/commons/crypto/stream/CtrCryptoStreamTest.java
@@ -44,7 +44,7 @@ public class CtrCryptoStreamTest extends AbstractCipherStreamTest {
     }
 
     @Override
-    protected CtrCryptoInputStream getCryptoInputStream(
+    protected CtrCryptoInputStream newCryptoInputStream(
             final ByteArrayInputStream bais, final CryptoCipher cipher, final int bufferSize,
             final byte[] iv, final boolean withChannel) throws IOException {
         if (withChannel) {
@@ -55,7 +55,7 @@ public class CtrCryptoStreamTest extends AbstractCipherStreamTest {
     }
 
     @Override
-    protected CtrCryptoInputStream getCryptoInputStream(final String transformation, final Properties props,
+    protected CtrCryptoInputStream newCryptoInputStream(final String transformation, final Properties props,
             final ByteArrayInputStream bais, final byte[] key, final AlgorithmParameterSpec params,
             final boolean withChannel) throws IOException {
         if (withChannel) {
@@ -66,7 +66,7 @@ public class CtrCryptoStreamTest extends AbstractCipherStreamTest {
     }
 
     @Override
-    protected CtrCryptoOutputStream getCryptoOutputStream(
+    protected CtrCryptoOutputStream newCryptoOutputStream(
             final ByteArrayOutputStream baos, final CryptoCipher cipher, final int bufferSize,
             final byte[] iv, final boolean withChannel) throws IOException {
         if (withChannel) {
@@ -77,7 +77,7 @@ public class CtrCryptoStreamTest extends AbstractCipherStreamTest {
     }
 
     @Override
-    protected CtrCryptoOutputStream getCryptoOutputStream(final String transformation,
+    protected CtrCryptoOutputStream newCryptoOutputStream(final String transformation,
             final Properties props, final ByteArrayOutputStream baos, final byte[] key,
             final AlgorithmParameterSpec params, final boolean withChannel) throws IOException {
         if (withChannel) {
@@ -165,7 +165,7 @@ public class CtrCryptoStreamTest extends AbstractCipherStreamTest {
     protected void doDecryptTest(final String cipherClass, final boolean withChannel)
             throws IOException {
 
-        final CtrCryptoInputStream in = getCryptoInputStream(new ByteArrayInputStream(encData),
+        final CtrCryptoInputStream in = newCryptoInputStream(new ByteArrayInputStream(encData),
                 getCipher(cipherClass), defaultBufferSize, iv, withChannel);
 
         final ByteBuffer buf = ByteBuffer.allocateDirect(dataLen);


### PR DESCRIPTION
Following up on Marcelo's recommendation to Dockerize the build process, submitted for review is a Dockerfile that automates the following builds:

Linux x86_64
Linux-arm
Linux-armfh
Linux-aarch64
Windows x86_64

This Dockerfile copies the project directory into the Docker image, so if you run it from a Mac after a successful local build, the resulting image will contain a jar that includes the above builds and the Mac build.  I've tested the Linux x86_64, Windows x86_64 and Mac x86_64 builds.  I have not tested the ARM builds, as I lack the platform to do so.

Note that this doesn't automate the Mac build, but Google suggests that it is possible.  I'll make the effort it if there's interest.

https://github.com/tpoechtrager/osxcross
https://github.com/multiarch/crossbuild

I included a Maven profile that runs the Dockerfile from Maven after a local build, but the plugin doesn't include much logging.  I'd recommend just running the Dockerfile from the command line, which will give you plenty of log output.

I don't pretend to be a Docker wizard, so feedback is appreciated.  There's probably a more efficient way to do this if anyone wants to give it a go.  The build process takes between ten and fifteen minutes on my machine because I build OpenSSL from source for each architecture to generate the platform-specific opensslconf.h file that's required for each build.  I'm not completely sure that it's necessary for purposes of building the JNI libraries, so if that step can be eliminated it would speed up the build considerably.