### PR TITLE
Addresses https://issues.apache.org/jira/browse/CRYPTO-149

### DIFF
--- a/src/test/java/org/apache/commons/crypto/cipher/GcmCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/GcmCipherTest.java
@@ -198,7 +198,7 @@ public class GcmCipherTest {
 
         final Random r = new Random();
         final int textLength = r.nextInt(1024*1024);
-        final int ivLength = r.nextInt(60);
+        final int ivLength = r.nextInt(59) + 1;
         final int keyLength = 16;
         final int tagLength = 128;  // bits
         final int aadLength = r.nextInt(128);


### PR DESCRIPTION
Fixes the test bug by restricting the initialization vector length to only valid values.