### PR TITLE
Standardizing Release Build Process with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file runs builds for the Linux-x86_64, Linux aarch64, Linux-arm, Linux-armfh and Win64 
+# architectures.  It copies the contents of the build host's project directory (commons-crypto) 
+# into the docker image, builds and tests the x86_64 build natively, and then cross compiles the 
+# remaining builds.  If you run this script from a Mac after a successful build, the build in the 
+# resuing Docker image will also include the Mac build by virtue of the initial project directory 
+# copy.
+
+FROM ubuntu:14.04
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ENV MAVEN_HOME=/opt/maven
+ENV PATH=${MAVEN_HOME}/bin:${PATH}
+# Install 64-bit dependencies and tooling.
+RUN apt-get update && apt-get --assume-yes install software-properties-common \
+      && add-apt-repository ppa:openjdk-r/ppa && apt-get update \
+      && apt-get --assume-yes install openjdk-8-jdk \
+      && apt-get --assume-yes install build-essential \
+      && apt-get --assume-yes install libssl-dev \
+      && apt-get --assume-yes install gcc-aarch64-linux-gnu \
+      && apt-get --assume-yes install g++-aarch64-linux-gnu \
+      && apt-get --assume-yes install mingw-w64 \
+      && apt-get --assume-yes install wget \
+# Bug workaround see https://github.com/docker-library/openjdk/issues/19.
+      && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
+# The default Maven with 14.04 doesn't support the required HTTPS protocol by default.
+      && wget https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
+      && tar xf apache-maven-*.tar.gz -C /opt && ln -s /opt/apache-maven-3.6.3 /opt/maven \
+# Copy the opensslconf.h file to the base openssl include directory.
+      && cp /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl \
+# Create the build directory.
+      && mkdir commons-crypto 
+COPY . /commons-crypto
+# Run the 64-bit builds.
+RUN cd commons-crypto && mvn package && mvn -DskipTests package -P linux-aarch64 \
+      && mvn -DskipTests package -P win64 \
+# Install 32-bit dependencies and tooling.
+      && dpkg --add-architecture i386 && apt-get update \
+      && apt-get --assume-yes install libssl-dev:i386 \
+      && apt-get --assume-yes install gcc-arm-linux-gnueabi \
+      && apt-get --assume-yes install g++-arm-linux-gnueabi \
+      && apt-get --assume-yes install gcc-arm-linux-gnueabihf \
+      && apt-get --assume-yes install g++-arm-linux-gnueabihf \
+# Run the 32-bit builds.
+      && mvn -DskipTests package -P linux-arm && mvn -DskipTests package -P linux-armhf

--- a/Makefile.common
+++ b/Makefile.common
@@ -154,8 +154,8 @@ SunOS-x86_64_COMMONS_CRYPTO_FLAGS  :=
 Linux-arm_CC        := $(CROSS_PREFIX)gcc
 Linux-arm_CXX       := $(CROSS_PREFIX)g++
 Linux-arm_STRIP     := $(CROSS_PREFIX)strip
-Linux-arm_CFLAGS    := -include lib/inc_linux/jni_md.h -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
-Linux-arm_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
+Linux-arm_CFLAGS    := -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
+Linux-arm_CXXFLAGS  := -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=softfp
 Linux-arm_LINKFLAGS := -shared -static-libgcc
 Linux-arm_LIBNAME   := libcommons-crypto.so
 Linux-arm_COMMONS_CRYPTO_FLAGS:=
@@ -163,8 +163,8 @@ Linux-arm_COMMONS_CRYPTO_FLAGS:=
 Linux-armhf_CC        := $(CROSS_PREFIX)gcc
 Linux-armhf_CXX       := $(CROSS_PREFIX)g++
 Linux-armhf_STRIP     := $(CROSS_PREFIX)strip
-Linux-armhf_CFLAGS    := -include lib/inc_linux/jni_md.h -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
-Linux-armhf_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
+Linux-armhf_CFLAGS    := -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
+Linux-armhf_CXXFLAGS  := -I"$(JAVA_HOME)/include" -O2 -fPIC -fvisibility=hidden -mfloat-abi=hard
 Linux-armhf_LINKFLAGS := -shared -static-libgcc
 Linux-armhf_LIBNAME   := libcommons-crypto.so
 Linux-armhf_COMMONS_CRYPTO_FLAGS:=

--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,24 @@ The following provides more details on the included cryptographic software:
         </plugins>
       </build>
     </profile>
-
+    <profile>
+      <id>build</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>0.33.0</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
This PR replaces a previous closed PR and has a cleaner commit history.  It provides a Dockerfile that automates the build for the following architectures:

Linux-x86_64
Linux-arm
Linux-armhf
LInux-aarch64
Win64

Per previous reviews, it leverages Ubuntu 14.04 as the base image.  If the Dockerfile is run from a Mac following a successful build, it will include the Mac build by virtue of copying the build directory into the Docker image.  Also included for convenience is a Maven profile that provides an option for running the Dockerfile from Maven.