### PR TITLE
[CRYPTO-156] - Common Class Padding and Transform

### DIFF
--- a/src/main/java/org/apache/commons/crypto/OpenSslTransform.java
+++ b/src/main/java/org/apache/commons/crypto/OpenSslTransform.java
@@ -1,0 +1,77 @@
+ /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.crypto;
+
+ /**
+  *
+  * Utility code for dealing with different algorithms,modes and types.
+  * <p>
+  * The {@code OpenSslTransform} class provide information about the operation to be performed on the given input.
+  * It is necessary to deal with the modes, padding and the algorithm.
+  * </p>
+  *
+  *  <ul>
+  *    <li><b>algorithm</b> (e.g., AES)</li>
+  *    <li><b>mode</b>      (e.g., CTR)</li>
+  *    <li><b>padding</b>   (e.g., PKCS5Padding)</li>
+  *  </ul>
+  *
+  * @since 1.1
+  */
+public class OpenSslTransform {
+    final String algorithm;
+    final String mode;
+    final String padding;
+
+    /**
+     * Constructor of Transform.
+     *
+     * @param algorithm the algorithm name
+     * @param mode      the mode name
+     * @param padding   the padding name
+     */
+    public OpenSslTransform(final String algorithm, final String mode, final String padding) {
+        this.algorithm = algorithm;
+        this.mode = mode;
+        this.padding = padding;
+    }
+    /**
+     * Gets the algorithm name.
+     *
+     * @return the algorithm name
+     */
+    public String getAlgorithm() {
+        return algorithm;
+    }
+    /**
+     * Gets the mode name.
+     *
+     * @return the mode name
+     */
+    public String getMode() {
+        return mode;
+    }
+    /**
+     * Gets the padding name.
+     *
+     * @return the padding name
+     */
+    public String getPadding() {
+        return padding;
+    }
+}

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSsl.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSsl.java
@@ -29,6 +29,7 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.ShortBufferException;
 
 import org.apache.commons.crypto.Crypto;
+import org.apache.commons.crypto.OpenSslTransform;
 import org.apache.commons.crypto.utils.Utils;
 
 /**
@@ -42,50 +43,6 @@ final class OpenSsl {
     public static final int DECRYPT_MODE = 0;
 
     private final OpenSslFeedbackCipher opensslBlockCipher;
-
-    /** Currently only support AES/CTR/NoPadding. */
-    private enum AlgorithmMode {
-        AES_CTR, AES_CBC, AES_GCM;
-
-        /**
-         * Gets the mode.
-         *
-         * @param algorithm the algorithm.
-         * @param mode the mode.
-         * @return the Algorithm mode.
-         * @throws NoSuchAlgorithmException if the algorithm is not available.
-         */
-        static int get(final String algorithm, final String mode)
-                throws NoSuchAlgorithmException {
-            try {
-                return AlgorithmMode.valueOf(algorithm + "_" + mode).ordinal();
-            } catch (final Exception e) {
-                throw new NoSuchAlgorithmException(
-                        "Doesn't support algorithm: " + algorithm
-                                + " and mode: " + mode);
-            }
-        }
-    }
-
-    private enum Padding {
-        NoPadding, PKCS5Padding;
-
-        /**
-         * Gets the Padding instance.
-         *
-         * @param padding the padding.
-         * @return the value of Padding.
-         * @throws NoSuchPaddingException if the padding is not available.
-         */
-        static int get(final String padding) throws NoSuchPaddingException {
-            try {
-                return Padding.valueOf(padding).ordinal();
-            } catch (final Exception e) {
-                throw new NoSuchPaddingException("Doesn't support padding: "
-                        + padding);
-            }
-        }
-    }
 
     private static final Throwable loadingFailureReason;
 
@@ -121,7 +78,7 @@ final class OpenSsl {
      * @param padding the padding.
      */
     private OpenSsl(final long context, final int algorithm, final int padding) {
-        if (algorithm == AlgorithmMode.AES_GCM.ordinal()) {
+        if (algorithm == OpenSslAlgorithmMode.AES_GCM.ordinal()) {
             opensslBlockCipher = new OpenSslGaloisCounterMode(context, algorithm, padding);
         } else {
             opensslBlockCipher = new OpenSslCommonMode(context, algorithm, padding);
@@ -147,42 +104,22 @@ final class OpenSsl {
         if (loadingFailureReason != null) {
             throw new IllegalStateException(loadingFailureReason);
         }
-        final Transform transform = tokenizeTransformation(transformation);
-        final int algorithmMode = AlgorithmMode.get(transform.algorithm,
-                transform.mode);
-        final int padding = Padding.get(transform.padding);
+        final OpenSslTransform openSslTransform = tokenizeTransformation(transformation);
+        final int algorithmMode = OpenSslAlgorithmMode.get(openSslTransform.getAlgorithm(),
+                openSslTransform.getMode()).ordinal();
+        final int padding = OpenSslPadding.get(openSslTransform.getPadding());
         final long context = OpenSslNative.initContext(algorithmMode, padding);
         return new OpenSsl(context, algorithmMode, padding);
-    }
-
-    /** Nested class for algorithm, mode and padding. */
-    private static class Transform {
-        final String algorithm;
-        final String mode;
-        final String padding;
-
-        /**
-         * Constructs a {@link Transform} based on the algorithm, mode and padding.
-         *
-         * @param algorithm the algorithm
-         * @param mode the mode.
-         * @param padding the padding.
-         */
-        public Transform(final String algorithm, final String mode, final String padding) {
-            this.algorithm = algorithm;
-            this.mode = mode;
-            this.padding = padding;
-        }
     }
 
     /**
      * Gets the tokens of transformation.
      *
      * @param transformation the transformation.
-     * @return the {@link Transform} instance.
+     * @return the {@link OpenSslTransform} instance.
      * @throws NoSuchAlgorithmException if the transformation is null.
      */
-    private static Transform tokenizeTransformation(final String transformation)
+    private static OpenSslTransform tokenizeTransformation(final String transformation)
             throws NoSuchAlgorithmException {
         if (transformation == null) {
             throw new NoSuchAlgorithmException("No transformation given.");
@@ -203,7 +140,7 @@ final class OpenSsl {
             throw new NoSuchAlgorithmException(
                     "Invalid transformation format: " + transformation);
         }
-        return new Transform(parts[0], parts[1], parts[2]);
+        return new OpenSslTransform(parts[0], parts[1], parts[2]);
     }
 
     /**

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslAlgorithmMode.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslAlgorithmMode.java
@@ -1,0 +1,57 @@
+ /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.crypto.cipher;
+
+import java.security.NoSuchAlgorithmException;
+
+ /**
+  * Enumeration of Algorithm Mode.
+  *
+  * @since 1.1
+  */
+ public enum OpenSslAlgorithmMode {
+
+     /**
+      * Counter mode.
+      */
+     AES_CTR,
+     /**
+      * Cipher Block Chaining Mode
+      */
+     AES_CBC,
+     /**
+      * Galois/Counter Mode
+      */
+     AES_GCM;
+
+     /**
+      * Gets the OpenSslAlgorithmMode instance.
+      *
+      * @param algorithm the algorithm name
+      * @param mode      the mode name
+      * @return the {@code OpenSslAlgorithmMode} instance
+      * @throws NoSuchAlgorithmException if the algorithm is not support
+      */
+     public static OpenSslAlgorithmMode get(final String algorithm, final String mode) throws NoSuchAlgorithmException {
+         try {
+             return valueOf(algorithm + "_" + mode);
+         } catch (final Exception e) {
+             throw new NoSuchAlgorithmException("Doesn't support algorithm: " + algorithm + " and mode: " + mode);
+         }
+     }
+}

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslPadding.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslPadding.java
@@ -1,0 +1,81 @@
+ /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.crypto.cipher;
+
+import javax.crypto.NoSuchPaddingException;
+
+
+ /**
+  * Enumeration of Algorithm Padding.
+  *
+  * @since 1.1
+  */
+public enum OpenSslPadding {
+     /**
+      * No padding.
+      */
+    NO_PADDING ("NoPadding"),
+     /**
+      * PKCS5 Padding
+      */
+    PKCS5_PADDING ("PKCS5Padding");
+
+     /** The enumeration name. */
+     private final String padding;
+
+    /**
+     * Constructs a new instance.
+     */
+     OpenSslPadding(final String padding) {
+         this.padding = padding;
+     }
+     /**
+     * Gets the Padding Ordinal value.
+     *
+     * @param padding the padding to find.
+     * @return the value of ordinal Padding.
+     * @throws NoSuchPaddingException if the padding is not available.
+     */
+    public static int get(final String padding) throws NoSuchPaddingException {
+        return forName(padding).ordinal();
+    }
+     /**
+      * Factory method to create an OpenSslPadding from a padding.
+      *
+      * @param padding the padding to find.
+      * @return the OpenSslPadding object
+      * @throws NoSuchPaddingException if the padding is not available.
+      */
+     public static OpenSslPadding forName(final String padding) throws NoSuchPaddingException {
+         for (final OpenSslPadding paddingCase : OpenSslPadding.values()) {
+             if (paddingCase.getPadding().equals(padding)) {
+                 return paddingCase;
+             }
+         }
+         throw new NoSuchPaddingException("Invalid Padding padding: " + padding);
+     }
+
+     /**
+      * Gets the name of the padding.
+      *
+      * @return the name of the padding
+      */
+     public String getPadding() {
+         return padding;
+     }
+ }

--- a/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCipher.java
+++ b/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCipher.java
@@ -31,24 +31,26 @@ import java.util.StringTokenizer;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 
+import org.apache.commons.crypto.cipher.OpenSslAlgorithmMode;
 import org.apache.commons.crypto.cipher.CryptoCipher;
 import org.apache.commons.crypto.cipher.CryptoCipherFactory;
 
 import com.sun.jna.NativeLong;
 import com.sun.jna.ptr.PointerByReference;
+import org.apache.commons.crypto.cipher.OpenSslPadding;
+import org.apache.commons.crypto.OpenSslTransform;
 
-/**
+ /**
  * Implements the CryptoCipher using JNA into OpenSSL.
  */
 class OpenSslJnaCipher implements CryptoCipher {
 
     private PointerByReference algo;
     private final PointerByReference context;
-    private final AlgorithmMode algMode;
+    private final OpenSslAlgorithmMode algMode;
     private final int padding;
     private final String transformation;
     private final int IV_LENGTH = 16;
@@ -66,14 +68,14 @@ class OpenSslJnaCipher implements CryptoCipher {
             throw new GeneralSecurityException("Could not enable JNA access", OpenSslJna.initialisationError());
         }
         this.transformation = transformation;
-        final Transform transform = tokenizeTransformation(transformation);
-        algMode = AlgorithmMode.get(transform.algorithm, transform.mode);
+        final OpenSslTransform openSslTransform = tokenizeTransformation(transformation);
+        algMode = OpenSslAlgorithmMode.get(openSslTransform.getAlgorithm(), openSslTransform.getMode());
 
-        if (algMode != AlgorithmMode.AES_CBC && algMode != AlgorithmMode.AES_CTR) {
-            throw new GeneralSecurityException("unknown algorithm " + transform.algorithm + "_" + transform.mode);
+        if (algMode != OpenSslAlgorithmMode.AES_CBC && algMode != OpenSslAlgorithmMode.AES_CTR) {
+            throw new GeneralSecurityException("unknown algorithm " + openSslTransform.getAlgorithm() + "_" + openSslTransform.getMode());
         }
 
-        padding = Padding.get(transform.padding);
+        padding = OpenSslPadding.get(openSslTransform.getPadding());
         context = OpenSslNativeJna.EVP_CIPHER_CTX_new();
 
     }
@@ -105,12 +107,12 @@ class OpenSslJnaCipher implements CryptoCipher {
             throw new InvalidAlgorithmParameterException("Illegal parameters");
         }
 
-        if ((algMode == AlgorithmMode.AES_CBC || algMode == AlgorithmMode.AES_CTR) && iv.length != IV_LENGTH) {
+        if ((algMode == OpenSslAlgorithmMode.AES_CBC || algMode == OpenSslAlgorithmMode.AES_CTR) && iv.length != IV_LENGTH) {
             throw new InvalidAlgorithmParameterException("Wrong IV length: must be 16 bytes long");
         }
         final int keyEncodedLength = key.getEncoded().length;
 
-        if (algMode == AlgorithmMode.AES_CBC) {
+        if (algMode == OpenSslAlgorithmMode.AES_CBC) {
             switch (keyEncodedLength) {
             case 16:
                 algo = OpenSslNativeJna.EVP_aes_128_cbc();
@@ -343,27 +345,6 @@ class OpenSslJnaCipher implements CryptoCipher {
         }
     }
 
-    // TODO DUPLICATED CODE, needs cleanup
-    /** Nested class for algorithm, mode and padding. */
-    private static class Transform {
-        final String algorithm;
-        final String mode;
-        final String padding;
-
-        /**
-         * Constructor of Transform.
-         *
-         * @param algorithm the algorithm name
-         * @param mode      the mode name
-         * @param padding   the padding name
-         */
-        public Transform(final String algorithm, final String mode, final String padding) {
-            this.algorithm = algorithm;
-            this.mode = mode;
-            this.padding = padding;
-        }
-    }
-
     /**
      * Tokenize the transformation.
      *
@@ -371,7 +352,7 @@ class OpenSslJnaCipher implements CryptoCipher {
      * @return the Transform
      * @throws NoSuchAlgorithmException if the algorithm is not supported
      */
-    private static Transform tokenizeTransformation(final String transformation) throws NoSuchAlgorithmException {
+    private static OpenSslTransform tokenizeTransformation(final String transformation) throws NoSuchAlgorithmException {
         if (transformation == null) {
             throw new NoSuchAlgorithmException("No transformation given.");
         }
@@ -390,52 +371,7 @@ class OpenSslJnaCipher implements CryptoCipher {
         if (count != 3 || parser.hasMoreTokens()) {
             throw new NoSuchAlgorithmException("Invalid transformation format: " + transformation);
         }
-        return new Transform(parts[0], parts[1], parts[2]);
-    }
-
-    /**
-     * AlgorithmMode of JNA. Currently only support AES/CTR/NoPadding.
-     */
-    private enum AlgorithmMode {
-        AES_CTR, AES_CBC;
-
-        /**
-         * Gets the AlgorithmMode instance.
-         *
-         * @param algorithm the algorithm name
-         * @param mode      the mode name
-         * @return the AlgorithmMode instance
-         * @throws NoSuchAlgorithmException if the algorithm is not support
-         */
-        static AlgorithmMode get(final String algorithm, final String mode) throws NoSuchAlgorithmException {
-            try {
-                return AlgorithmMode.valueOf(algorithm + "_" + mode);
-            } catch (final Exception e) {
-                throw new NoSuchAlgorithmException("Doesn't support algorithm: " + algorithm + " and mode: " + mode);
-            }
-        }
-    }
-
-    /**
-     * Padding of JNA.
-     */
-    private enum Padding {
-        NoPadding, PKCS5Padding;
-
-        /**
-         * Gets the Padding instance.
-         *
-         * @param padding the padding name
-         * @return the AlgorithmMode instance
-         * @throws NoSuchPaddingException if the algorithm is not support
-         */
-        static int get(final String padding) throws NoSuchPaddingException {
-            try {
-                return Padding.valueOf(padding).ordinal();
-            } catch (final Exception e) {
-                throw new NoSuchPaddingException("Doesn't support padding: " + padding);
-            }
-        }
+        return new OpenSslTransform(parts[0], parts[1], parts[2]);
     }
 
     @Override


### PR DESCRIPTION
In order to avoid duplicate code and try to unify the transformation of the token i think it's necessary create the next class:

OpenSslTransform --> Utility code for dealing with different algorithm types
OpenSslPadding --> Containg the enumeration of Cipher Algorithm Padding
OpenSslAlgorithmMode --> Enumeration of Algorithm Mode.
https://github.com/apache/commons-crypto/blob/master/src/main/java/org/apache/commons/crypto/cipher/OpenSsl.java#L208
https://github.com/apache/commons-crypto/blob/master/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCipher.java#L422
https://github.com/apache/commons-crypto/blob/master/src/main/java/org/apache/commons/crypto/cipher/OpenSsl.java#L47
https://github.com/apache/commons-crypto/blob/master/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCipher.java#L399