### PR TITLE
Fix PMD warning and don't init to defaults

### DIFF
--- a/src/main/java/org/apache/commons/crypto/NativeCodeLoader.java
+++ b/src/main/java/org/apache/commons/crypto/NativeCodeLoader.java
@@ -19,7 +19,6 @@ package org.apache.commons.crypto;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -144,8 +143,9 @@ final class NativeCodeLoader {
                 return null;
             }
             // Extract a native library file into the target directory
+            final Path path;
             try {
-                final Path path = extractedLibFile.toPath();
+                path = extractedLibFile.toPath();
                 final long byteCount = Files.copy(inputStream, path, StandardCopyOption.REPLACE_EXISTING);
                 if (isDebug()) {
                     debug("Extracted '%s' to '%s': %,d bytes [%s]", nativeLibraryFilePath, extractedLibFile, byteCount,
@@ -171,7 +171,7 @@ final class NativeCodeLoader {
             // Check whether the contents are properly copied from the resource
             // folder
             try (InputStream nativeInputStream = NativeCodeLoader.class.getResourceAsStream(nativeLibraryFilePath)) {
-                try (InputStream extractedLibIn = new FileInputStream(extractedLibFile)) {
+                try (InputStream extractedLibIn = Files.newInputStream(path)) {
                     debug("Validating '%s'...", extractedLibFile);
                     if (!contentsEquals(nativeInputStream, extractedLibIn)) {
                         throw new IllegalStateException(String.format("Failed to write a native library file %s to %s",

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslCipher.java
@@ -37,7 +37,7 @@ import javax.crypto.ShortBufferException;
 class OpenSslCipher implements CryptoCipher {
 
     private final OpenSsl openSslEngine;
-    private boolean initialized = false;
+    private boolean initialized;
 
     private final String transformation;
 

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslFeedbackCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslFeedbackCipher.java
@@ -32,7 +32,7 @@ import org.apache.commons.crypto.utils.Utils;
  */
 abstract class OpenSslFeedbackCipher {
 
-    protected long context = 0;
+    protected long context;
     protected final int algorithmMode;
     protected final int padding;
 

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslGaloisCounterMode.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslGaloisCounterMode.java
@@ -45,7 +45,7 @@ class OpenSslGaloisCounterMode extends OpenSslFeedbackCipher {
     static final int DEFAULT_TAG_LEN = 16;
 
     // buffer for storing input in decryption, not used for encryption
-    private ByteArrayOutputStream inBuffer = null;
+    private ByteArrayOutputStream inBuffer;
 
     public OpenSslGaloisCounterMode(final long context, final int algorithmMode, final int padding) {
         super(context, algorithmMode, padding);

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
@@ -76,7 +76,7 @@ public class CryptoInputStream extends InputStream implements
     /**
      * Flag to mark whether do final of the cipher to end the decrypting stream.
      */
-    private boolean finalDone = false;
+    private boolean finalDone;
 
     /** The input data. */
     Input input; // package protected for access by crypto classes; do not expose further
@@ -587,16 +587,16 @@ public class CryptoInputStream extends InputStream implements
             .clean(); */
             final String SUN_CLASS = "sun.nio.ch.DirectBuffer";
             final Class<?>[] interfaces = buffer.getClass().getInterfaces();
+            final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
             for (final Class<?> clazz : interfaces) {
                 if (clazz.getName().equals(SUN_CLASS)) {
-                    final Object[] NO_PARAM = new Object[0];
                     /* DirectBuffer#cleaner() */
                     final Method getCleaner = Class.forName(SUN_CLASS).getMethod("cleaner");
-                    final Object cleaner = getCleaner.invoke(buffer, NO_PARAM);
+                    final Object cleaner = getCleaner.invoke(buffer, EMPTY_OBJECT_ARRAY);
                     /* Cleaner#clean() */
                     final Method cleanMethod = Class.forName("sun.misc.Cleaner").getMethod("clean");
-                    cleanMethod.invoke(cleaner, NO_PARAM);
+                    cleanMethod.invoke(cleaner, EMPTY_OBJECT_ARRAY);
                     return;
                 }
             }

--- a/src/main/java/org/apache/commons/crypto/stream/CtrCryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CtrCryptoInputStream.java
@@ -53,7 +53,7 @@ public class CtrCryptoInputStream extends CryptoInputStream {
     /**
      * Underlying stream offset
      */
-    private long streamOffset = 0;
+    private long streamOffset;
 
     /**
      * The initial IV.
@@ -75,7 +75,7 @@ public class CtrCryptoInputStream extends CryptoInputStream {
     /**
      * Flag to mark whether the cipher has been reset
      */
-    private boolean cipherReset = false;
+    private boolean cipherReset;
 
     /**
      * Constructs a {@link CtrCryptoInputStream}.

--- a/src/main/java/org/apache/commons/crypto/stream/CtrCryptoOutputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CtrCryptoOutputStream.java
@@ -57,7 +57,7 @@ public class CtrCryptoOutputStream extends CryptoOutputStream {
     /**
      * Underlying stream offset.
      */
-    private long streamOffset = 0;
+    private long streamOffset;
 
     /**
      * The initial IV.
@@ -79,7 +79,7 @@ public class CtrCryptoOutputStream extends CryptoOutputStream {
     /**
      * Flag to mark whether the cipher has been reset
      */
-    private boolean cipherReset = false;
+    private boolean cipherReset;
 
     /**
      * Constructs a {@link CtrCryptoOutputStream}.

--- a/src/test/java/org/apache/commons/crypto/cipher/GcmCipherTest.java
+++ b/src/test/java/org/apache/commons/crypto/cipher/GcmCipherTest.java
@@ -40,8 +40,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GcmCipherTest {
 
-    Properties props = null;
-    String cipherClass = null;
+    Properties props;
+    String cipherClass;
     String transformation = "AES/GCM/NoPadding";
 
     private String[] kHex;


### PR DESCRIPTION
* Remove Redundant Field Initializer
* Use Files.newInputStream(Paths.get(fileName))
* Remove Instantiating Objects In Loops