### PR TITLE
Update Build Process and Documentation CRYPTO-132 and CRYPTO-120

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -16,6 +16,7 @@ Requirements:
 
 Profile win64 on Ubuntu 64-bit:
 apt-get install mingw-w64
+
 apt install x86_64-w64-mingw32-gcc
 
 Profile win32 on Ubuntu 64-bit:
@@ -41,12 +42,12 @@ Copy downloaded local_policy.jar and US_export_policy.jar to <java-home>/jre/lib
 ----------------------------------------------------------------------------------
 Verify OpenSSL version:
 
+Check OpenSSL version:
+
   $ openssl version
 
 If it is not 1.1.1, upgrade OpenSSL version to 1.1.1:
 
-<<<<<<< HEAD
-<<<<<<< Upstream, based on upstream/master
 Upgrade OpenSSL in Linux:
 
 You can follow your OS distribution instructions to upgrade OpenSSL to a proper version.
@@ -56,10 +57,6 @@ Upgrade OpenSSL in Mac:
   $ brew install openssl111
   $ brew link openssl --force
 
-=======
->>>>>>> 974c3cd Updated build documentation.
-=======
->>>>>>> branch 'master' of https://github.com/aremily/commons-crypto.git
 Get OpenSSL headers: sudo apt -y install libssl-dev
 
 Cross compile to 32-bit from Linux 64-bit: sudo apt-get install gcc-multilib

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -16,7 +16,6 @@ Requirements:
 
 Profile win64 on Ubuntu 64-bit:
 apt-get install mingw-w64
-
 apt install x86_64-w64-mingw32-gcc
 
 Profile win32 on Ubuntu 64-bit:
@@ -42,12 +41,11 @@ Copy downloaded local_policy.jar and US_export_policy.jar to <java-home>/jre/lib
 ----------------------------------------------------------------------------------
 Verify OpenSSL version:
 
-Check OpenSSL version:
-
   $ openssl version
 
 If it is not 1.1.1, upgrade OpenSSL version to 1.1.1:
 
+<<<<<<< Upstream, based on upstream/master
 Upgrade OpenSSL in Linux:
 
 You can follow your OS distribution instructions to upgrade OpenSSL to a proper version.
@@ -57,6 +55,8 @@ Upgrade OpenSSL in Mac:
   $ brew install openssl111
   $ brew link openssl --force
 
+=======
+>>>>>>> 974c3cd Updated build documentation.
 Get OpenSSL headers: sudo apt -y install libssl-dev
 
 Cross compile to 32-bit from Linux 64-bit: sudo apt-get install gcc-multilib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file runs builds for the Linux-x86_64, Linux aarch64, Linux-arm, Linux-armfh and Win64 
+# architectures.  It copies the contents of the build host's project directory (commons-crypto) 
+# into the docker image, builds and tests the x86_64 build natively, and then cross compiles the 
+# remaining builds.  If you run this script from a Mac after a successful Mac build, the build in  
+# the resuing Docker image will also include the Mac build by virtue of the initial project directory
+# copy.
+
+FROM ubuntu:14.04
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ENV MAVEN_HOME=/opt/maven
+ENV PATH=${MAVEN_HOME}/bin:${PATH}
+# Install 64-bit dependencies and tooling.
+RUN apt-get update && apt-get --assume-yes install software-properties-common \
+      && add-apt-repository ppa:openjdk-r/ppa && apt-get update \
+      && apt-get --assume-yes install openjdk-8-jdk \
+      && apt-get --assume-yes install build-essential \
+      && apt-get --assume-yes install libssl-dev \
+      && apt-get --assume-yes install gcc-aarch64-linux-gnu \
+      && apt-get --assume-yes install g++-aarch64-linux-gnu \
+      && apt-get --assume-yes install mingw-w64 \
+      && apt-get --assume-yes install wget \
+# Bug workaround see https://github.com/docker-library/openjdk/issues/19.
+      && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
+# The default Maven with 14.04 doesn't support the required HTTPS protocol by default.
+      && wget https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
+      && tar xf apache-maven-*.tar.gz -C /opt && ln -s /opt/apache-maven-3.6.3 /opt/maven \
+# Copy the opensslconf.h file to the base openssl include directory.
+      && cp /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl \
+# Create the build directory.
+      && mkdir commons-crypto
+COPY . /commons-crypto
+# Run the 64-bit builds.
+RUN cd commons-crypto && mvn package && mvn -DskipTests package -P linux-aarch64 \
+      && mvn -DskipTests package -P win64
+# Install 32-bit dependencies and tooling.
+RUN dpkg --add-architecture i386 && apt-get update \
+      && apt-get --assume-yes install libssl-dev:i386 \
+      && apt-get --assume-yes install gcc-arm-linux-gnueabi \
+      && apt-get --assume-yes install g++-arm-linux-gnueabi \
+      && apt-get --assume-yes install gcc-arm-linux-gnueabihf \
+      && apt-get --assume-yes install g++-arm-linux-gnueabihf
+# Run the 32-bit builds.
+RUN cd commons-crypto && mvn -DskipTests package -P linux-armhf \
+      && mvn -DskipTests package -P linux-arm

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get --assume-yes install software-properties-common \
 COPY . /commons-crypto
 # Run the 64-bit builds.
 RUN cd commons-crypto && mvn package && mvn -DskipTests package -P linux-aarch64 \
-      && mvn -DskipTests package -P win64
+      && mvn -DskipTests package -P win64 
 # Install 32-bit dependencies and tooling.
 RUN dpkg --add-architecture i386 && apt-get update \
       && apt-get --assume-yes install libssl-dev:i386 \
@@ -56,4 +56,11 @@ RUN dpkg --add-architecture i386 && apt-get update \
       && apt-get --assume-yes install g++-arm-linux-gnueabihf
 # Run the 32-bit builds.
 RUN cd commons-crypto && mvn -DskipTests package -P linux-armhf \
-      && mvn -DskipTests package -P linux-arm
+      && mvn -DskipTests package -P linux-arm \
+      && mvn -DskipTests package -P win32
+# Install multilib and run the linux32 build.  Installing multilib overwrites the existing gcc
+# installations.
+RUN apt-get --assume-yes install gcc-multilib \
+      && apt-get --assume-yes install g++-multilib \
+      && cd commons-crypto && mvn -DskipTests package -P linux32
+# Export the artifact from the container at /commons-crypto/target/artifact-id.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file runs builds for the Linux-x86_64, Linux aarch64, Linux-arm, Linux-armfh and Win64 
-# architectures.  It copies the contents of the build host's project directory (commons-crypto) 
+# This file runs builds for the Linux-x86_64, Linux aarch64, Linux-arm, Linux-armfh and Win64 and  
+# Win32 architectures.  It copies the contents of the build host's project directory (commons-crypto) 
 # into the docker image, builds and tests the x86_64 build natively, and then cross compiles the 
 # remaining builds.  If you run this script from a Mac after a successful Mac build, the build in  
 # the resuing Docker image will also include the Mac build by virtue of the initial project directory
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get --assume-yes install software-properties-common \
 # Bug workaround see https://github.com/docker-library/openjdk/issues/19.
       && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
 # The default Maven with 14.04 doesn't support the required HTTPS protocol by default.
-      && wget https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
+      && wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
       && tar xf apache-maven-*.tar.gz -C /opt && ln -s /opt/apache-maven-3.6.3 /opt/maven \
 # Copy the opensslconf.h file to the base openssl include directory.
       && cp /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get --assume-yes install software-properties-common \
 # Bug workaround see https://github.com/docker-library/openjdk/issues/19.
       && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
 # The default Maven with 14.04 doesn't support the required HTTPS protocol by default.
-      && wget https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
+      && wget https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
       && tar xf apache-maven-*.tar.gz -C /opt && ln -s /opt/apache-maven-3.6.3 /opt/maven \
 # Copy the opensslconf.h file to the base openssl include directory.
       && cp /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl \

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@ The following provides more details on the included cryptographic software:
     <!-- This is used by reporting plugins -->
     <project.reporting.outputEncoding>${commons.encoding}</project.reporting.outputEncoding>
 
-    <checkstyle.version>3.1.2</checkstyle.version>
+    <checkstyle.version>3.1.0</checkstyle.version>
     <checkstyle.header.file>${basedir}/LICENSE-header.txt</checkstyle.header.file>
     <checkstyle.resourceExcludes>LICENSE.txt, NOTICE.txt, **/maven-archiver/pom.properties</checkstyle.resourceExcludes>
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -27,7 +27,7 @@
             <item name="Overview"      href="/index.html"/>
             <item name="Download"
                    href="https://commons.apache.org/proper/commons-crypto/download_crypto.cgi"/>
-            <item name="Users guide"   href="/userguide.html"/>
+            <item name="Users Guide"   href="/userguide.html"/>
             <item name="FAQ"           href="/faq.html"/>
             <item name="Javadoc"       href="/apidocs/index.html"/>
         </menu>

--- a/src/site/xdoc/userguide.xml
+++ b/src/site/xdoc/userguide.xml
@@ -132,10 +132,9 @@
 					cross compiled--so it is not included in the Dockerfile. If you
 					endeavor to produce a multi-platform build that includes the JNI
 					libraries for OSX, you must run the OSX build locally on a Mac
-					first, and then you can run the Dockerfile to perform the balance
-					of the builds. The Dockerfile will copy the output of the OSX build
-					into the container, where it will become a part of the complete
-					build.
+					first, and then run the Dockerfile to perform the balance of the
+					builds. The Dockerfile will copy the output of the OSX build into
+					the container, where it will become a part of the complete build.
 				</p>
 			</subsection>
 			<subsection name="Interfaces Overview">
@@ -172,7 +171,8 @@
 							automatically
 							encrypts
 							the stream when data is written and
-							decrypts the stream when data
+							decrypts the stream
+							when data
 							is
 							read.
 						</td>
@@ -287,13 +287,10 @@
 
 				<h4>Usage of Stream API</h4>
 				<p>
-					Stream provides the data encryption and decryption in stream
-					manner. We
-					provide CryptoInputStream,
-					CTRCryptoInputStream,
+					Stream provides the data encryption and decryption in stream manner. We
+					provide CryptoInputStream, CTRCryptoInputStream,
 					PositionedCryptoInputStream implementations for InputStream and
-					CryptoOutputStream,
-					CTRCryptoOutputStream implementations for
+					CryptoOutputStream, CTRCryptoOutputStream implementations for
 					OutputStream.
 				</p>
 				<h5>Usage of stream encryption/decryption</h5>

--- a/src/site/xdoc/userguide.xml
+++ b/src/site/xdoc/userguide.xml
@@ -19,28 +19,28 @@
         <p>Apache Commons Crypto is a Java wrapper around certain common features of OpenSSL, and also supports corresponding JCE features.  As such, it provides near-native performance to the Java developer via a Java API. It provides Java API for both cipher level and Java stream level, leveraging AES-NI (Advanced Encryption Standard New Instructions) when run on supported hardware. Developers can use it to implement high performance AES encryption and decryption with minimal code and effort. Note that Apache Commons Crypto doesn't implement the cryptographic algorithms directly, but instead delegates to OpenSSL or JCE as algorithm providers.</p>
         <subsection name="Building from Source">
           <p>As of release 1.1.0, Apache Commons Crypto supports the following architectures:</p>
-            <ul>Windows x86</ul>
-            <ul>Windows x86_64</ul>
-            <ul>OSX x86_64</ul>
-            <ul>Linux x86</ul>
-            <ul>Linux x86_64</ul>
-            <ul>Linux aarch64</ul>
-            <ul>Linux arm</ul>
-            <ul>Linux armhf</ul>
+            <li>Windows x86</li>
+            <li>Windows x86_64</li>
+            <li>OSX x86_64</li>
+            <li>Linux x86</li>
+            <li>Linux x86_64</li>
+            <li>Linux aarch64</li>
+            <li>Linux arm</li>
+            <li>Linux armhf</li><br/>
           <p>Each supported platform has a corresponding JNI library that must be compiled to the target native architecture during the build process. This native compilation renders an Apache Commons Crypto build more complex than a typical Java build that compiles only to the JVM. A developer's first build experience with Apache Commons Crypto will likely be a single architecture build. Single architecture builds are generally performed by developers working on new features in their local development environment. Multi-platform builds are generally performed during the release process. Single architecture builds for release 1.1.0 have been performed and tested on Windows x86_64, Linux x86_64 and OSX x86_64. The balance of builds have been cross-compiled on Ubuntu 14.04 and tested on their respective architectures.</p>
           <h4>Prerequisites</h4>
-            <ul>Unix System (Linux or Mac), or Windows with MinGW</ul>
-            <ul>JDK 8 or above (environment variable JAVA_HOME must be set)</ul>
-            <ul>Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files (if running unit tests)</ul>
-            <ul>export JAVA_HOME</ul>
-            <ul>Maven 3.0 or above</ul>
-            <ul>Make</ul>
-            <ul>OpenSSL devel 1.1.1 or above (OpenSSL library header files are required) </ul>
-            <ul> GCC</ul>
-            <ul> G++</ul>
+            <li>Unix System (Linux or Mac), or Windows with MinGW</li>
+            <li>JDK 8 or above (environment variable JAVA_HOME must be set)</li>
+            <li>Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files (if running unit tests)</li>
+            <li>export JAVA_HOME</li>
+            <li>Maven 3.1.1 or above</li>
+            <li>Make</li>
+            <li>OpenSSL devel 1.1.1 or above (OpenSSL library header files are required) </li>
+            <li>GCC</li>
+            <li>G++</li>
           <h4>Single Architecture Build</h4>
             <p>Once the prerequisites have been met, run the single architecture build using the standard Maven build process.</p>
-          <h4>Multi-architecture Build</h4>
+          <h4>Multi Architecture Build</h4>
             <p>The Apache Commons Crypto team recommends performing a multi-platform build by running the Dockerfile from the project base directory, and then copying the artifact from the resulting container to your host. For a combination of legal, licensing and technical reasons, the Mac build must be performed on a Mac--not cross compiled--so it is not included in the Dockerfile. If you endeavor to produce a multi-platform build that includes the JNI libraries for OSX, you must run the OSX build locally on a Mac first, and then run the Dockerfile to perform the balance of the builds. The Dockerfile will copy the output of the OSX build into the container, where it will become a part of the complete build.</p>
         </subsection>
         <subsection name="Interfaces Overview">
@@ -67,16 +67,15 @@
         </subsection>
         <subsection name="Usage">
           <h4>Prerequisites</h4>
-            <p>Commons Crypto relies on standard JDK 1.8 (or above) and OpenSSL 1.1.1 for production deployment. If it is installed, the command <code>openssl version</code> can be used to show the version.</p>
-            <p>OpenSSL may already be installed on your system; if not, please visit <a href="https://www.openssl.org/">OpenSSL.org</a>for information on installation.</p>
+            <p>Commons Crypto relies on standard JDK 1.8 (or above) and supports OpenSSL 1.0.x and 1.1.x for production deployment. OpenSSL may already be installed on your system; if so, the command <code>openssl version</code> can be used to show the version.  If not please visit <a href="https://www.openssl.org/">OpenSSL.org</a> for information on installation.</p>
           <h4>Using Commons Crypto in your Apache Maven build</h4>
-            <p>To build with Apache Maven, add the dependencies listed below to your pom.xml file. </p>
-              <pre>&lt;dependency&gt;
-                <br />&lt;groupId&gt;org.apache.commons&lt;/groupId&gt;
-                <br />&lt;artifactId&gt;commons-crypto&lt;/artifactId&gt;
-                <br />&lt;version&gt;1.1.0&lt;/version&gt;
-                <br /> &lt;/dependency&gt;
-                <br />
+            <p>To build with Apache Maven, add the dependencies listed below to your pom.xml file. Note that version 1.1.0 is fully backwards compatible with previous versions, so new projects should use version 1.1.0 and existing projects can upgrade seamlessly.</p>
+              <pre>
+&lt;dependency&gt;<br/>
+    &lt;groupId&gt;org.apache.commons&lt;/groupId&gt;<br/>        
+    &lt;artifactId&gt;commons-crypto&lt;/artifactId&gt;<br/>
+    &lt;version&gt;1.1.0&lt;/version&gt;<br/>
+&lt;/dependency&gt;
               </pre>
           <h4>Usage of Random API</h4>
             <p>CryptoRandom provides a cryptographically strong random number generators. The default implementation will use Intel® Digital Random Number Generator (DRNG)for accelerating the random generation. </p>

--- a/src/site/xdoc/userguide.xml
+++ b/src/site/xdoc/userguide.xml
@@ -18,7 +18,7 @@
       <section name="User Guide">
         <p>Apache Commons Crypto is a Java wrapper around certain common features of OpenSSL, and also supports corresponding JCE features.  As such, it provides near-native performance to the Java developer via a Java API. It provides Java API for both cipher level and Java stream level, leveraging AES-NI (Advanced Encryption Standard New Instructions) when run on supported hardware. Developers can use it to implement high performance AES encryption and decryption with minimal code and effort. Note that Apache Commons Crypto doesn't implement the cryptographic algorithms directly, but instead delegates to OpenSSL or JCE as algorithm providers.</p>
         <subsection name="Building from Source">
-          <p>As of release 1.1.0, Apache Commons Crypto supports the following architectures:
+          <p>As of release 1.1.0, Apache Commons Crypto supports the following architectures:</p>
             <ul>Windows x86</ul>
             <ul>Windows x86_64</ul>
             <ul>OSX x86_64</ul>
@@ -27,7 +27,7 @@
             <ul>Linux aarch64</ul>
             <ul>Linux arm</ul>
             <ul>Linux armhf</ul>
-          Each supported platform has a corresponding JNI library that must be compiled to the target native architecture during the build process. This native compilation renders an Apache Commons Crypto build more complex than a typical Java build that compiles only to the JVM. A developer's first build experience with Apache Commons Crypto will likely be a single architecture build. Single architecture builds are generally performed by developers working on new features in their local development environment. Multi-platform builds are generally performed during the release process. Single architecture builds for release 1.1.0 have been performed and tested on Windows x86_64, Linux x86_64 and OSX x86_64. The balance of builds have been cross-compiled on Ubuntu 14.04 and tested on their respective architectures.
+          <p>Each supported platform has a corresponding JNI library that must be compiled to the target native architecture during the build process. This native compilation renders an Apache Commons Crypto build more complex than a typical Java build that compiles only to the JVM. A developer's first build experience with Apache Commons Crypto will likely be a single architecture build. Single architecture builds are generally performed by developers working on new features in their local development environment. Multi-platform builds are generally performed during the release process. Single architecture builds for release 1.1.0 have been performed and tested on Windows x86_64, Linux x86_64 and OSX x86_64. The balance of builds have been cross-compiled on Ubuntu 14.04 and tested on their respective architectures.</p>
           <h4>Prerequisites</h4>
             <ul>Unix System (Linux or Mac), or Windows with MinGW</ul>
             <ul>JDK 8 or above (environment variable JAVA_HOME must be set)</ul>
@@ -39,9 +39,9 @@
             <ul> GCC</ul>
             <ul> G++</ul>
           <h4>Single Architecture Build</h4>
-            Once the prerequisites have been met, run the single architecture build using the standard Maven build process.
+            <p>Once the prerequisites have been met, run the single architecture build using the standard Maven build process.</p>
           <h4>Multi-architecture Build</h4>
-            The Apache Commons Crypto team recommends performing a multi-platform build by running the Dockerfile from the project base directory, and then copying the artifact from the resulting container to your host. For a combination of legal, licensing and technical reasons, the Mac build must be performed on a Mac--not cross compiled--so it is not included in the Dockerfile. If you endeavor to produce a multi-platform build that includes the JNI libraries for OSX, you must run the OSX build locally on a Mac first, and then run the Dockerfile to perform the balance of the builds. The Dockerfile will copy the output of the OSX build into the container, where it will become a part of the complete build.</p>
+            <p>The Apache Commons Crypto team recommends performing a multi-platform build by running the Dockerfile from the project base directory, and then copying the artifact from the resulting container to your host. For a combination of legal, licensing and technical reasons, the Mac build must be performed on a Mac--not cross compiled--so it is not included in the Dockerfile. If you endeavor to produce a multi-platform build that includes the JNI libraries for OSX, you must run the OSX build locally on a Mac first, and then run the Dockerfile to perform the balance of the builds. The Dockerfile will copy the output of the OSX build into the container, where it will become a part of the complete build.</p>
         </subsection>
         <subsection name="Interfaces Overview">
           <p>Interfaces and classes used by the various implementation in the sub-packages.</p>

--- a/src/site/xdoc/userguide.xml
+++ b/src/site/xdoc/userguide.xml
@@ -1,479 +1,98 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-	license agreements. See the NOTICE file distributed with this work for additional 
-	information regarding copyright ownership. The ASF licenses this file to 
-	You under the Apache License, Version 2.0 (the "License"); you may not use 
-	this file except in compliance with the License. You may obtain a copy of 
-	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-	by applicable law or agreed to in writing, software distributed under the 
-	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-	OF ANY KIND, either express or implied. See the License for the specific 
-	language governing permissions and limitations under the License. -->
-<document>
-<<<<<<< HEAD
-<<<<<<< Upstream, based on upstream/master
-  <properties>
-    <title>Commons Crypto - User guide</title>
-    <author email="dev@commons.apache.org">Commons Documentation Team</author>
-  </properties>
-  <body>
-    <section name="User guide">
-      <p>Apache Commons Crypto is a cryptographic library optimized with AES-NI
-        (Advanced Encryption
-        Standard New Instructions). It provides Java API for both cipher level and Java stream
-        level. Developers can use it to implement high performance AES encryption/decryption with
-        the minimum code and effort. 
-      </p>
-      <p>
-        Please note that Apache Commons Crypto doesn't implement the cryptographic
-        algorithm such as AES directly. It wraps Openssl or JCE which implement the algorithms.
-        OpenSSL 1.1.1 is required for building and running.
-      </p>
-      <subsection name="Interfaces Overview">
-        <p>Interfaces and classes used by the various implementation in the sub-packages.</p>
-        <table>
-          <tr>
-            <td width="150">
-              <a href="apidocs/index.html">random
-              </a>
-            </td>
-            <td>
-              The interface for CryptoRandom.
-            </td>
-          </tr>
-          <tr>
-            <td width="150">
-              <a href="apidocs/index.html">cipher
-              </a>
-            </td>
-            <td>
-              The interface of cryptographic cipher for encryption and decryption.
-            </td>
-          </tr>
-          <tr>
-            <td width="150">
-              <a href="apidocs/index.html">stream
-              </a>
-            </td>
-            <td>
-              The interface wraps the underlying stream and it automatically encrypts
-              the stream when data is written and decrypts the stream when data is
-              read.
-            </td>
-          </tr>
-        </table>
-      </subsection>
-=======
-	<properties>
-		<title>Commons Crypto - User guide</title>
-		<author email="dev@commons.apache.org">Commons Documentation Team</author>
-	</properties>
-	<body>
-		<section name="User Guide">
-			<p>Apache Commons Crypto is a Java wrapper around certain common
-				features of OpenSSL, and also supports corresponding JCE features.
-				As such, it provides near-native performance to the Java developer
-				via a Java API. It provides Java API for both cipher level and Java
-				stream level, leveraging AES-NI (Advanced Encryption Standard New
-				Instructions) when run on supported hardware. Developers can use it
-				to implement high performance AES encryption/decryption with minimal
-				code and effort. Note that Apache Commons Crypto doesn't implement
-				the cryptographic algorithms directly, but instead delegates to
-				OpenSSL or JCE as algorithm providers.
-			</p>
-			<subsection name="Building from Source">
-				<p>
-					As of release 1.1.0, Apache Commons Crypto supports the following
-					architectures:
-					<ul>Windows x86</ul>
-					<ul>Windows x86_64</ul>
-					<ul>OSX x86_64</ul>
-					<ul>Linux x86</ul>
-					<ul>Linux x86_64</ul>
-					<ul>Linux aarch64</ul>
-					<ul>Linux arm</ul>
-					<ul>Linux armhf</ul>
-					Each supported platform has a corresponding JNI library that must
-					be compiled to the target native architecture during the build
-					process. This native compilation renders an Apache Commons Crypto
-					build more complex than a typical Java build that compiles only to
-					the JVM. A developer's first build experience with Apache Commons
-					Crypto will likely be a single architecture build. Single
-					architecture builds are generally performed by developers working
-					on new features in their local development environment.
-					Multi-platform builds are generally performed during the release
-					process. Single architecture builds for release 1.1.0 have been
-					performed and tested on Windows x86_64, Linux x86_64 and OSX
-					x86_64. The balance of builds have been cross-compiled on Ubuntu
-					14.04 and tested on their respective architectures.
-					<h4>Prerequisites</h4>
-					<ul>Unix System (Linux or Mac), or Windows with MinGW</ul>
-					<ul>JDK 8 or above (environment variable JAVA_HOME must be set)
-					</ul>
-					<ul>Java Cryptography Extension (JCE) Unlimited Strength
-						Jurisdiction Policy Files (if running unit tests)
-					</ul>
-					<ul>export JAVA_HOME</ul>
-					<ul>Maven 3.0 or above</ul>
-					<ul>Make</ul>
-					<ul>OpenSSL devel 1.1.1 or above (OpenSSL library header files are
-						required)
-					</ul>
-					<ul> GCC</ul>
-					<ul> G++</ul>
-					<h4>Single Architecture Build</h4>
-					Once the prerequisites have been met, run the single architecture
-					build using the standard Maven build process.
-					<h4>Multi-architecture Build</h4>
-					The Apache Commons Crypto team recommends performing a
-					multi-platform build by running the Dockerfile from the project
-					base directory, and then copying the artifact from the resulting
-					container to your host. For a combination of legal, licensing and
-					technical reasons, the Mac build must be performed on Mac OSX--not
-					cross compiled--so it is not included in the Dockerfile. If you
-					endeavor to produce a multi-platform build that includes the JNI
-					libraries for OSX, you must run the OSX build locally on a Mac
-					first, and then run the Dockerfile to perform the balance of the
-					builds. The Dockerfile will copy the output of the OSX build into
-					the container, where it will become a part of the complete build.
-				</p>
-			</subsection>
-			<subsection name="Interfaces Overview">
-				<p>Interfaces and classes used by the various implementation in the
-					sub-packages.
-				</p>
-				<table>
-					<tr>
-						<td width="150">
-							<a href="apidocs/index.html">random
-							</a>
-						</td>
-						<td>
-							The interface for CryptoRandom.
-						</td>
-					</tr>
-					<tr>
-						<td width="150">
-							<a href="apidocs/index.html">cipher
-							</a>
-						</td>
-						<td>
-							The interface of cryptographic cipher for encryption and
-							decryption.
-						</td>
-					</tr>
-					<tr>
-						<td width="150">
-							<a href="apidocs/index.html">stream
-							</a>
-						</td>
-						<td>
-							The interface wraps the underlying stream and it
-							automatically
-							encrypts
-							the stream when data is written and
-							decrypts the stream
-							when data
-							is
-							read.
-						</td>
-					</tr>
-				</table>
-			</subsection>
->>>>>>> 974c3cd Updated build documentation.
-=======
-	<properties>
-		<title>Commons Crypto - User guide</title>
-		<author email="dev@commons.apache.org">Commons Documentation Team</author>
-	</properties>
-	<body>
-		<section name="User Guide">
-			<p>Apache Commons Crypto is a Java wrapper around certain common
-				features of OpenSSL, and also supports corresponding JCE features.
-				As such, it provides near-native performance to the Java developer
-				via a Java API. It provides Java API for both cipher level and Java
-				stream level, leveraging AES-NI (Advanced Encryption Standard New
-				Instructions) when run on supported hardware. Developers can use it
-				to implement high performance AES encryption/decryption with minimal
-				code and effort. Note that Apache Commons Crypto doesn't implement
-				the cryptographic algorithms directly, but instead delegates to
-				OpenSSL or JCE as algorithm providers.
-			</p>
-			<subsection name="Building from Source">
-				<p>
-					As of release 1.1.0, Apache Commons Crypto supports the following
-					architectures:
-					<ul>Windows x86</ul>
-					<ul>Windows x86_64</ul>
-					<ul>OSX x86_64</ul>
-					<ul>Linux x86</ul>
-					<ul>Linux x86_64</ul>
-					<ul>Linux aarch64</ul>
-					<ul>Linux arm</ul>
-					<ul>Linux armhf</ul>
-					Each supported platform has a corresponding JNI library that must
-					be compiled to the target native architecture during the build
-					process. This native compilation renders an Apache Commons Crypto
-					build more complex than a typical Java build that compiles only to
-					the JVM. A developer's first build experience with Apache Commons
-					Crypto will likely be a single architecture build. Single
-					architecture builds are generally performed by developers working
-					on new features in their local development environment.
-					Multi-platform builds are generally performed during the release
-					process. Single architecture builds for release 1.1.0 have been
-					performed and tested on Windows x86_64, Linux x86_64 and OSX
-					x86_64. The balance of builds have been cross-compiled on Ubuntu
-					14.04 and tested on their respective architectures.
-					<h4>Prerequisites</h4>
-					<ul>Unix System (Linux or Mac), or Windows with MinGW</ul>
-					<ul>JDK 8 or above (environment variable JAVA_HOME must be set)
-					</ul>
-					<ul>Java Cryptography Extension (JCE) Unlimited Strength
-						Jurisdiction Policy Files (if running unit tests)
-					</ul>
-					<ul>export JAVA_HOME</ul>
-					<ul>Maven 3.0 or above</ul>
-					<ul>Make</ul>
-					<ul>OpenSSL devel 1.1.1 or above (OpenSSL library header files are
-						required)
-					</ul>
-					<ul> GCC</ul>
-					<ul> G++</ul>
-					<h4>Single Architecture Build</h4>
-					Once the prerequisites have been met, run the single architecture
-					build using the standard Maven build process.
-					<h4>Multi-architecture Build</h4>
-					The Apache Commons Crypto team recommends performing a
-					multi-platform build by running the Dockerfile from the project
-					base directory, and then copying the artifact from the resulting
-					container to your host. For a combination of legal, licensing and
-					technical reasons, the Mac build must be performed on Mac OSX--not
-					cross compiled--so it is not included in the Dockerfile. If you
-					endeavor to produce a multi-platform build that includes the JNI
-					libraries for OSX, you must run the OSX build locally on a Mac
-					first, and then run the Dockerfile to perform the balance of the
-					builds. The Dockerfile will copy the output of the OSX build into
-					the container, where it will become a part of the complete build.
-				</p>
-			</subsection>
-			<subsection name="Interfaces Overview">
-				<p>Interfaces and classes used by the various implementation in the
-					sub-packages.
-				</p>
-				<table>
-					<tr>
-						<td width="150">
-							<a href="apidocs/index.html">random
-							</a>
-						</td>
-						<td>
-							The interface for CryptoRandom.
-						</td>
-					</tr>
-					<tr>
-						<td width="150">
-							<a href="apidocs/index.html">cipher
-							</a>
-						</td>
-						<td>
-							The interface of cryptographic cipher for encryption and
-							decryption.
-						</td>
-					</tr>
-					<tr>
-						<td width="150">
-							<a href="apidocs/index.html">stream
-							</a>
-						</td>
-						<td>
-							The interface wraps the underlying stream and it
-							automatically
-							encrypts
-							the stream when data is written and
-							decrypts the stream
-							when data
-							is
-							read.
-						</td>
-					</tr>
-				</table>
-			</subsection>
->>>>>>> branch 'master' of https://github.com/aremily/commons-crypto.git
-
-<<<<<<< HEAD
-<<<<<<< Upstream, based on upstream/master
-      <subsection name ="Usage">
+  license agreements. See the NOTICE file distributed with this work for additional 
+  information regarding copyright ownership. The ASF licenses this file to 
+  You under the Apache License, Version 2.0 (the "License"); you may not use 
+  this file except in compliance with the License. You may obtain a copy of 
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+  by applicable law or agreed to in writing, software distributed under the 
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+  OF ANY KIND, either express or implied. See the License for the specific 
+  language governing permissions and limitations under the License. -->
+  <document>
+    <properties>
+      <title>Commons Crypto - User guide</title>
+      <author email="dev@commons.apache.org">Commons Documentation Team</author>
+    </properties>
+    <body>
+      <section name="User Guide">
+        <p>Apache Commons Crypto is a Java wrapper around certain common features of OpenSSL, and also supports corresponding JCE features.  As such, it provides near-native performance to the Java developer via a Java API. It provides Java API for both cipher level and Java stream level, leveraging AES-NI (Advanced Encryption Standard New Instructions) when run on supported hardware. Developers can use it to implement high performance AES encryption and decryption with minimal code and effort. Note that Apache Commons Crypto doesn't implement the cryptographic algorithms directly, but instead delegates to OpenSSL or JCE as algorithm providers.</p>
+        <subsection name="Building from Source">
+          <p>As of release 1.1.0, Apache Commons Crypto supports the following architectures:
+            <ul>Windows x86</ul>
+            <ul>Windows x86_64</ul>
+            <ul>OSX x86_64</ul>
+            <ul>Linux x86</ul>
+            <ul>Linux x86_64</ul>
+            <ul>Linux aarch64</ul>
+            <ul>Linux arm</ul>
+            <ul>Linux armhf</ul>
+          Each supported platform has a corresponding JNI library that must be compiled to the target native architecture during the build process. This native compilation renders an Apache Commons Crypto build more complex than a typical Java build that compiles only to the JVM. A developer's first build experience with Apache Commons Crypto will likely be a single architecture build. Single architecture builds are generally performed by developers working on new features in their local development environment. Multi-platform builds are generally performed during the release process. Single architecture builds for release 1.1.0 have been performed and tested on Windows x86_64, Linux x86_64 and OSX x86_64. The balance of builds have been cross-compiled on Ubuntu 14.04 and tested on their respective architectures.
           <h4>Prerequisites</h4>
-          <p>
-            Commons Crypto relies on standard JDK 1.8 (or above) and OpenSSL 1.1.1 for production
-            deployment. 
-            If it is installed, the command <code>openssl version</code> can be used to show the version.
-          </p>
-          <p>OpenSSL may already be installed on your system; if not, please visit
-            <a href="https://www.openssl.org/">OpenSSL.org</a> for information on installation.
-          </p>
+            <ul>Unix System (Linux or Mac), or Windows with MinGW</ul>
+            <ul>JDK 8 or above (environment variable JAVA_HOME must be set)</ul>
+            <ul>Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files (if running unit tests)</ul>
+            <ul>export JAVA_HOME</ul>
+            <ul>Maven 3.0 or above</ul>
+            <ul>Make</ul>
+            <ul>OpenSSL devel 1.1.1 or above (OpenSSL library header files are required) </ul>
+            <ul> GCC</ul>
+            <ul> G++</ul>
+          <h4>Single Architecture Build</h4>
+            Once the prerequisites have been met, run the single architecture build using the standard Maven build process.
+          <h4>Multi-architecture Build</h4>
+            The Apache Commons Crypto team recommends performing a multi-platform build by running the Dockerfile from the project base directory, and then copying the artifact from the resulting container to your host. For a combination of legal, licensing and technical reasons, the Mac build must be performed on a Mac--not cross compiled--so it is not included in the Dockerfile. If you endeavor to produce a multi-platform build that includes the JNI libraries for OSX, you must run the OSX build locally on a Mac first, and then run the Dockerfile to perform the balance of the builds. The Dockerfile will copy the output of the OSX build into the container, where it will become a part of the complete build.</p>
+        </subsection>
+        <subsection name="Interfaces Overview">
+          <p>Interfaces and classes used by the various implementation in the sub-packages.</p>
+            <table>
+              <tr>
+                <td width="150">
+                  <a href="apidocs/index.html">random</a>
+                </td>
+                <td>The interface for CryptoRandom.</td>
+              </tr>
+              <tr>
+                <td width="150">
+                  <a href="apidocs/index.html">cipher</a>
+                </td>
+                <td>The interface of cryptographic cipher for encryption and decryption.</td>
+              </tr>
+              <tr>
+                <td width="150">
+                  <a href="apidocs/index.html">stream</a></td>
+                <td>The interface wraps the underlying stream and it automatically encrypts the stream when data is written anddecrypts the stream when data is read.</td>
+              </tr>
+            </table>
+        </subsection>
+        <subsection name="Usage">
+          <h4>Prerequisites</h4>
+            <p>Commons Crypto relies on standard JDK 1.8 (or above) and OpenSSL 1.1.1 for production deployment. If it is installed, the command <code>openssl version</code> can be used to show the version.</p>
+            <p>OpenSSL may already be installed on your system; if not, please visit <a href="https://www.openssl.org/">OpenSSL.org</a>for information on installation.</p>
           <h4>Using Commons Crypto in your Apache Maven build</h4>
-          <p>
-            To build with Apache Maven, add the dependencies listed below to your pom.xml file.
-          </p>
-<pre>
-&lt;dependency&gt;<br/>
-    &lt;groupId&gt;org.apache.commons&lt;/groupId&gt;<br/>
-    &lt;artifactId&gt;commons-crypto&lt;/artifactId&gt;<br/>
-    &lt;version&gt;1.1.0&lt;/version&gt;<br/>
-&lt;/dependency&gt;<br/>
-</pre>
-        <h4>Usage of Random API</h4>
-        <p>
-          CryptoRandom provides a cryptographically strong random number generators.
-          The default implementation will use Intel&reg; Digital Random Number Generator (DRNG)
-          for accelerating the random generation.
-        </p>
-=======
-			<subsection name="Usage">
-				<h4>Prerequisites</h4>
-				<p>
-					Commons Crypto relies on standard JDK 1.7 (or above) and OpenSSL
-					1.0.1c
-					(or above) for production
-					deployment.
-				</p>
-				<h4>Using Commons Crypto in your Apache Maven build</h4>
-				<p>
-					To build with Apache Maven, add the dependencies listed below to
-					your pom.xml file.
-				</p>
-				<pre>
-					&lt;dependency&gt;
-					<br />
-					&lt;groupId&gt;org.apache.commons&lt;/groupId&gt;
-					<br />
-					&lt;artifactId&gt;commons-crypto&lt;/artifactId&gt;
-					<br />
-					&lt;version&gt;1.1.0&lt;/version&gt;
-					<br />
-					&lt;/dependency&gt;
-					<br />
-				</pre>
-				<h4>Usage of Random API</h4>
-				<p>
-					CryptoRandom provides a cryptographically strong random number
-					generators.
-					The default implementation will use Intel® Digital
-					Random Number
-					Generator (DRNG)
-					for accelerating the random
-					generation.
-				</p>
->>>>>>> 974c3cd Updated build documentation.
-=======
-			<subsection name="Usage">
-				<h4>Prerequisites</h4>
-				<p>
-					Commons Crypto relies on standard JDK 1.7 (or above) and OpenSSL
-					1.0.1c
-					(or above) for production
-					deployment.
-				</p>
-				<h4>Using Commons Crypto in your Apache Maven build</h4>
-				<p>
-					To build with Apache Maven, add the dependencies listed below to
-					your pom.xml file.
-				</p>
-				<pre>
-					&lt;dependency&gt;
-					<br />
-					&lt;groupId&gt;org.apache.commons&lt;/groupId&gt;
-					<br />
-					&lt;artifactId&gt;commons-crypto&lt;/artifactId&gt;
-					<br />
-					&lt;version&gt;1.1.0&lt;/version&gt;
-					<br />
-					&lt;/dependency&gt;
-					<br />
-				</pre>
-				<h4>Usage of Random API</h4>
-				<p>
-					CryptoRandom provides a cryptographically strong random number
-					generators.
-					The default implementation will use Intel® Digital
-					Random Number
-					Generator (DRNG)
-					for accelerating the random
-					generation.
-				</p>
->>>>>>> branch 'master' of https://github.com/aremily/commons-crypto.git
-
-				<a
-					href="xref-test/org/apache/commons/crypto/examples/RandomExample.html">RandomExample.java</a>
-
-<<<<<<< HEAD
-<<<<<<< Upstream, based on upstream/master
-        <h4>Usage of Cipher API</h4>
-        <p>
-          Cipher provides an cryptographic interface for encryption and decryption.
-          We provide two kind of implementations: JCE Cipher and Openssl Cipher. The
-          JCE implementation uses JCE provider and the Openssl implementation uses
-          Intel&reg; AES New Instructions (Intel&reg; AES NI).
-        </p>
-        <h5>Usage of Byte Array Encryption/Decryption</h5>
-=======
-				<h4>Usage of Cipher API</h4>
-				<p>
-					Cipher provides an cryptographic interface for encryption and
-					decryption.
-					We provide two kind of implementations: JCE Cipher and
-					Openssl
-					Cipher. The
-					JCE implementation uses JCE provider and the
-					Openssl implementation
-					uses
-					Intel® AES New Instructions (Intel® AES
-					NI).
-				</p>
-				<h5>Usage of Byte Array Encryption/Decryption</h5>
->>>>>>> 974c3cd Updated build documentation.
-=======
-				<h4>Usage of Cipher API</h4>
-				<p>
-					Cipher provides an cryptographic interface for encryption and
-					decryption.
-					We provide two kind of implementations: JCE Cipher and
-					Openssl
-					Cipher. The
-					JCE implementation uses JCE provider and the
-					Openssl implementation
-					uses
-					Intel® AES New Instructions (Intel® AES
-					NI).
-				</p>
-				<h5>Usage of Byte Array Encryption/Decryption</h5>
->>>>>>> branch 'master' of https://github.com/aremily/commons-crypto.git
-
-				<a
-					href="xref-test/org/apache/commons/crypto/examples/CipherByteArrayExample.html">CipherByteArrayExample.java</a>
-
-				<h5>Usage of ByteBuffer Encryption/Decryption</h5>
-
-				<a
-					href="xref-test/org/apache/commons/crypto/examples/CipherByteBufferExample.html">CipherByteBufferExample.java</a>
-
-
-				<h4>Usage of Stream API</h4>
-				<p>
-					Stream provides the data encryption and decryption in stream manner. We
-					provide CryptoInputStream, CTRCryptoInputStream,
-					PositionedCryptoInputStream implementations for InputStream and
-					CryptoOutputStream, CTRCryptoOutputStream implementations for
-					OutputStream.
-				</p>
-				<h5>Usage of stream encryption/decryption</h5>
-
-				<a
-					href="xref-test/org/apache/commons/crypto/examples/StreamExample.html">StreamExample.java</a>
-
-			</subsection>
-		</section>
-	</body>
-</document>
+            <p>To build with Apache Maven, add the dependencies listed below to your pom.xml file. </p>
+              <pre>&lt;dependency&gt;
+                <br />&lt;groupId&gt;org.apache.commons&lt;/groupId&gt;
+                <br />&lt;artifactId&gt;commons-crypto&lt;/artifactId&gt;
+                <br />&lt;version&gt;1.1.0&lt;/version&gt;
+                <br /> &lt;/dependency&gt;
+                <br />
+              </pre>
+          <h4>Usage of Random API</h4>
+            <p>CryptoRandom provides a cryptographically strong random number generators. The default implementation will use Intel® Digital Random Number Generator (DRNG)for accelerating the random generation. </p>
+            <a href="xref-test/org/apache/commons/crypto/examples/RandomExample.html">RandomExample.java</a>
+          <h4>Usage of Cipher API</h4>
+            <p> Cipher provides an cryptographic interface for encryption and decryption. We provide two kinds of implementations: JCE Cipher and OpenSSL Cipher. The JCE implementation uses JCE provider and the OpenSSL implementation uses Intel&reg; AES New Instructions (Intel&reg;AES NI). </p>
+          <h5>Usage of Byte Array Encryption/Decryption</h5>
+            <a href="xref-test/org/apache/commons/crypto/examples/CipherByteArrayExample.html">CipherByteArrayExample.java</a>
+          <h5>Usage of ByteBuffer Encryption/Decryption</h5>
+            <a href="xref-test/org/apache/commons/crypto/examples/CipherByteBufferExample.html">CipherByteBufferExample.java</a>
+          <h4>Usage of Stream API</h4>
+            <p>Stream provides the data encryption and decryption in stream manner. We provide CryptoInputStream, CTRCryptoInputStream, PositionedCryptoInputStream implementations for InputStream and CryptoOutputStream, CTRCryptoOutputStream implementations for  OutputStream. </p>
+          <h5>Usage of stream encryption/decryption</h5>
+            <a href="xref-test/org/apache/commons/crypto/examples/StreamExample.html">StreamExample.java</a>
+        </subsection>
+      </section>
+    </body>
+  </document>
 

--- a/src/site/xdoc/userguide.xml
+++ b/src/site/xdoc/userguide.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
-  license agreements. See the NOTICE file distributed with this work for additional
-  information regarding copyright ownership. The ASF licenses this file to
-  You under the Apache License, Version 2.0 (the "License"); you may not use
-  this file except in compliance with the License. You may obtain a copy of
-  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
-  by applicable law or agreed to in writing, software distributed under the
-  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-  OF ANY KIND, either express or implied. See the License for the specific
-  language governing permissions and limitations under the License. -->
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	You under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
 <document>
+<<<<<<< Upstream, based on upstream/master
   <properties>
     <title>Commons Crypto - User guide</title>
     <author email="dev@commons.apache.org">Commons Documentation Team</author>
@@ -61,7 +62,126 @@
           </tr>
         </table>
       </subsection>
+=======
+	<properties>
+		<title>Commons Crypto - User guide</title>
+		<author email="dev@commons.apache.org">Commons Documentation Team</author>
+	</properties>
+	<body>
+		<section name="User Guide">
+			<p>Apache Commons Crypto is a Java wrapper around certain common
+				features of OpenSSL, and also supports corresponding JCE features.
+				As such, it provides near-native performance to the Java developer
+				via a Java API. It provides Java API for both cipher level and Java
+				stream level, leveraging AES-NI (Advanced Encryption Standard New
+				Instructions) when run on supported hardware. Developers can use it
+				to implement high performance AES encryption/decryption with minimal
+				code and effort. Note that Apache Commons Crypto doesn't implement
+				the cryptographic algorithms directly, but instead delegates to
+				OpenSSL or JCE as algorithm providers.
+			</p>
+			<subsection name="Building from Source">
+				<p>
+					As of release 1.1.0, Apache Commons Crypto supports the following
+					architectures:
+					<ul>Windows x86</ul>
+					<ul>Windows x86_64</ul>
+					<ul>OSX x86_64</ul>
+					<ul>Linux x86</ul>
+					<ul>Linux x86_64</ul>
+					<ul>Linux aarch64</ul>
+					<ul>Linux arm</ul>
+					<ul>Linux armhf</ul>
+					Each supported platform has a corresponding JNI library that must
+					be compiled to the target native architecture during the build
+					process. This native compilation renders an Apache Commons Crypto
+					build more complex than a typical Java build that compiles only to
+					the JVM. A developer's first build experience with Apache Commons
+					Crypto will likely be a single architecture build. Single
+					architecture builds are generally performed by developers working
+					on new features in their local development environment.
+					Multi-platform builds are generally performed during the release
+					process. Single architecture builds for release 1.1.0 have been
+					performed and tested on Windows x86_64, Linux x86_64 and OSX
+					x86_64. The balance of builds have been cross-compiled on Ubuntu
+					14.04 and tested on their respective architectures.
+					<h4>Prerequisites</h4>
+					<ul>Unix System (Linux or Mac), or Windows with MinGW</ul>
+					<ul>JDK 8 or above (environment variable JAVA_HOME must be set)
+					</ul>
+					<ul>Java Cryptography Extension (JCE) Unlimited Strength
+						Jurisdiction Policy Files (if running unit tests)
+					</ul>
+					<ul>export JAVA_HOME</ul>
+					<ul>Maven 3.0 or above</ul>
+					<ul>Make</ul>
+					<ul>OpenSSL devel 1.1.1 or above (OpenSSL library header files are
+						required)
+					</ul>
+					<ul> GCC</ul>
+					<ul> G++</ul>
+					<h4>Single Architecture Build</h4>
+					Once the prerequisites have been met, run the single architecture
+					build using the standard Maven build process.
+					<h4>Multi-architecture Build</h4>
+					The Apache Commons Crypto team recommends performing a
+					multi-platform build by running the Dockerfile from the project
+					base directory, and then copying the artifact from the resulting
+					container to your host. For a combination of legal, licensing and
+					technical reasons, the Mac build must be performed on Mac OSX--not
+					cross compiled--so it is not included in the Dockerfile. If you
+					endeavor to produce a multi-platform build that includes the JNI
+					libraries for OSX, you must run the OSX build locally on a Mac
+					first, and then you can run the Dockerfile to perform the balance
+					of the builds. The Dockerfile will copy the output of the OSX build
+					into the container, where it will become a part of the complete
+					build.
+				</p>
+			</subsection>
+			<subsection name="Interfaces Overview">
+				<p>Interfaces and classes used by the various implementation in the
+					sub-packages.
+				</p>
+				<table>
+					<tr>
+						<td width="150">
+							<a href="apidocs/index.html">random
+							</a>
+						</td>
+						<td>
+							The interface for CryptoRandom.
+						</td>
+					</tr>
+					<tr>
+						<td width="150">
+							<a href="apidocs/index.html">cipher
+							</a>
+						</td>
+						<td>
+							The interface of cryptographic cipher for encryption and
+							decryption.
+						</td>
+					</tr>
+					<tr>
+						<td width="150">
+							<a href="apidocs/index.html">stream
+							</a>
+						</td>
+						<td>
+							The interface wraps the underlying stream and it
+							automatically
+							encrypts
+							the stream when data is written and
+							decrypts the stream when data
+							is
+							read.
+						</td>
+					</tr>
+				</table>
+			</subsection>
+>>>>>>> 974c3cd Updated build documentation.
 
+<<<<<<< Upstream, based on upstream/master
       <subsection name ="Usage">
           <h4>Prerequisites</h4>
           <p>
@@ -89,9 +209,48 @@
           The default implementation will use Intel&reg; Digital Random Number Generator (DRNG)
           for accelerating the random generation.
         </p>
+=======
+			<subsection name="Usage">
+				<h4>Prerequisites</h4>
+				<p>
+					Commons Crypto relies on standard JDK 1.7 (or above) and OpenSSL
+					1.0.1c
+					(or above) for production
+					deployment.
+				</p>
+				<h4>Using Commons Crypto in your Apache Maven build</h4>
+				<p>
+					To build with Apache Maven, add the dependencies listed below to
+					your pom.xml file.
+				</p>
+				<pre>
+					&lt;dependency&gt;
+					<br />
+					&lt;groupId&gt;org.apache.commons&lt;/groupId&gt;
+					<br />
+					&lt;artifactId&gt;commons-crypto&lt;/artifactId&gt;
+					<br />
+					&lt;version&gt;1.1.0&lt;/version&gt;
+					<br />
+					&lt;/dependency&gt;
+					<br />
+				</pre>
+				<h4>Usage of Random API</h4>
+				<p>
+					CryptoRandom provides a cryptographically strong random number
+					generators.
+					The default implementation will use Intel® Digital
+					Random Number
+					Generator (DRNG)
+					for accelerating the random
+					generation.
+				</p>
+>>>>>>> 974c3cd Updated build documentation.
 
-        <a href="xref-test/org/apache/commons/crypto/examples/RandomExample.html">RandomExample.java</a>
+				<a
+					href="xref-test/org/apache/commons/crypto/examples/RandomExample.html">RandomExample.java</a>
 
+<<<<<<< Upstream, based on upstream/master
         <h4>Usage of Cipher API</h4>
         <p>
           Cipher provides an cryptographic interface for encryption and decryption.
@@ -100,26 +259,50 @@
           Intel&reg; AES New Instructions (Intel&reg; AES NI).
         </p>
         <h5>Usage of Byte Array Encryption/Decryption</h5>
+=======
+				<h4>Usage of Cipher API</h4>
+				<p>
+					Cipher provides an cryptographic interface for encryption and
+					decryption.
+					We provide two kind of implementations: JCE Cipher and
+					Openssl
+					Cipher. The
+					JCE implementation uses JCE provider and the
+					Openssl implementation
+					uses
+					Intel® AES New Instructions (Intel® AES
+					NI).
+				</p>
+				<h5>Usage of Byte Array Encryption/Decryption</h5>
+>>>>>>> 974c3cd Updated build documentation.
 
-        <a href="xref-test/org/apache/commons/crypto/examples/CipherByteArrayExample.html">CipherByteArrayExample.java</a>
+				<a
+					href="xref-test/org/apache/commons/crypto/examples/CipherByteArrayExample.html">CipherByteArrayExample.java</a>
 
-        <h5>Usage of ByteBuffer Encryption/Decryption</h5>
+				<h5>Usage of ByteBuffer Encryption/Decryption</h5>
 
-        <a href="xref-test/org/apache/commons/crypto/examples/CipherByteBufferExample.html">CipherByteBufferExample.java</a>
+				<a
+					href="xref-test/org/apache/commons/crypto/examples/CipherByteBufferExample.html">CipherByteBufferExample.java</a>
 
 
-        <h4>Usage of Stream API</h4>
-        <p>
-          Stream provides the data encryption and decryption in stream manner. We provide CryptoInputStream,
-          CTRCryptoInputStream, PositionedCryptoInputStream implementations for InputStream and CryptoOutputStream,
-          CTRCryptoOutputStream implementations for OutputStream.
-        </p>
-        <h5>Usage of stream encryption/decryption</h5>
+				<h4>Usage of Stream API</h4>
+				<p>
+					Stream provides the data encryption and decryption in stream
+					manner. We
+					provide CryptoInputStream,
+					CTRCryptoInputStream,
+					PositionedCryptoInputStream implementations for InputStream and
+					CryptoOutputStream,
+					CTRCryptoOutputStream implementations for
+					OutputStream.
+				</p>
+				<h5>Usage of stream encryption/decryption</h5>
 
-        <a href="xref-test/org/apache/commons/crypto/examples/StreamExample.html">StreamExample.java</a>
+				<a
+					href="xref-test/org/apache/commons/crypto/examples/StreamExample.html">StreamExample.java</a>
 
-      </subsection>
-    </section>
-  </body>
+			</subsection>
+		</section>
+	</body>
 </document>
 


### PR DESCRIPTION
Adding a dockerfile that packages a build with all supported architectures except the Mac.  Updated the related user guide documentation.  Needed to roll  back the checkstyle plugin version to address https://github.com/jeremylong/DependencyCheck/issues/2492, or the "site" command fails.