### PR TITLE
Fixes grammar and typos and optimizes JavaDoc

### DIFF
--- a/PROPOSAL.html
+++ b/PROPOSAL.html
@@ -55,7 +55,7 @@
   
 
 <p>Providing Java based optimized and high performance cryptographic IO streams for 
-the applications who wants to implement the data encryption. It also provides cipher 
+the applications that want to implement the data encryption. It also provides cipher
 level API to use. It does provide the openssl API integration and provide the fallback 
 mechanism to use JCE when openssl library unavailable.</p>
 
@@ -75,7 +75,7 @@ which implement algorithms.)</p>
 
 of OpenSSL library. </p>
 
-<p>It focuses on AES-NI optimizations mainly and it can be extended to other algorithms
+<p>It focuses on AES-NI optimizations mainly, and it can be extended to other algorithms
 
  based on demand from the users later.</p>
 

--- a/src/main/java/org/apache/commons/crypto/Crypto.java
+++ b/src/main/java/org/apache/commons/crypto/Crypto.java
@@ -89,7 +89,7 @@ public final class Crypto {
      * by Maven.
      * </p>
      *
-     * @return the version; may be null if not found
+     * @return the version; may be {@code null} if not found
      */
     public static String getComponentName() {
         // Note: the component properties file allows the method to work without needing
@@ -105,7 +105,7 @@ public final class Crypto {
      * by Maven.
      * </p>
      *
-     * @return the version; may be null if not found
+     * @return the version; may be {@code null} if not found
      */
     public static String getComponentVersion() {
         // Note: the component properties file allows the method to work without needing
@@ -116,7 +116,7 @@ public final class Crypto {
     /**
      * The loading error throwable, if loading failed.
      *
-     * @return null, unless loading failed.
+     * @return {@code null}, unless loading failed.
      */
     public static Throwable getLoadingError() {
         return NativeCodeLoader.getLoadingError();
@@ -137,7 +137,7 @@ public final class Crypto {
     /**
      * Checks whether the native code has been successfully loaded for the platform.
      *
-     * @return true if the native code has been loaded successfully.
+     * @return {@code true} if the native code has been loaded successfully.
      */
     public static boolean isNativeCodeLoaded() {
         return NativeCodeLoader.isNativeCodeLoaded();

--- a/src/main/java/org/apache/commons/crypto/NativeCodeLoader.java
+++ b/src/main/java/org/apache/commons/crypto/NativeCodeLoader.java
@@ -68,10 +68,10 @@ final class NativeCodeLoader {
      * Copied from Apache Commons IO 2.5.
      * </p>
      *
-     * @param inputStream the InputStream to wrap or return (not null)
+     * @param inputStream the InputStream to wrap or return (not {@code null})
      * @return the given InputStream or a new {@link BufferedInputStream} for the
      *         given InputStream
-     * @throws NullPointerException if the input parameter is null
+     * @throws NullPointerException if the input parameter is {@code null}
      */
     @SuppressWarnings("resource")
     private static BufferedInputStream buffer(final InputStream inputStream) {
@@ -90,7 +90,7 @@ final class NativeCodeLoader {
      *
      * @param input1 the input1.
      * @param input2 the input2.
-     * @return true if in1 and in2 is equal, else false.
+     * @return {@code true} if in1 and in2 is equal, else {@code false}.
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("resource")

--- a/src/main/java/org/apache/commons/crypto/OpenSslInfoNative.java
+++ b/src/main/java/org/apache/commons/crypto/OpenSslInfoNative.java
@@ -38,7 +38,7 @@ final class OpenSslInfoNative {
     /**
      * Return the path to the loaded dynamic linked library.
      * [Currently not implemented on Windows]
-     * @return the path to the library that was loaded; may be null.
+     * @return the path to the library that was loaded; may be {@code null}.
      */
     public static native String DLLPath();
 

--- a/src/main/java/org/apache/commons/crypto/OsInfo.java
+++ b/src/main/java/org/apache/commons/crypto/OsInfo.java
@@ -157,7 +157,7 @@ final class OsInfo {
     }
 
     /**
-     * The main method. This is used by the JNI make processing in Makefile.common
+     * The main method. This is used by the JNI make processing in {@code Makefile.common}
      *
      * @param args the argv.
      */

--- a/src/main/java/org/apache/commons/crypto/cipher/CryptoCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/CryptoCipher.java
@@ -118,7 +118,7 @@ public interface CryptoCipher extends Closeable {
      *         policy files).
      * @throws InvalidAlgorithmParameterException if the given algorithm
      *         parameters are inappropriate for this cipher, or this cipher
-     *         requires algorithm parameters and {@code params} is null, or
+     *         requires algorithm parameters and {@code params} is {@code null}, or
      *         the given algorithm parameters imply a cryptographic strength
      *         that would exceed the legal limits (as determined from the
      *         configured jurisdiction policy files).

--- a/src/main/java/org/apache/commons/crypto/cipher/JceCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/JceCipher.java
@@ -152,7 +152,7 @@ class JceCipher implements CryptoCipher {
      * @param params the algorithm parameters
      * @throws InvalidAlgorithmParameterException if the given algorithm
      *         parameters are inappropriate for this cipher, or this cipher
-     *         requires algorithm parameters and {@code params} is null, or
+     *         requires algorithm parameters and {@code params} is {@code null}, or
      *         the given algorithm parameters imply a cryptographic strength
      *         that would exceed the legal limits (as determined from the
      *         configured jurisdiction policy files).
@@ -218,7 +218,7 @@ class JceCipher implements CryptoCipher {
      * @param aad the buffer containing the Additional Authentication Data
      *
      * @throws IllegalArgumentException if the {@code aad}
-     * byte array is null
+     * byte array is {@code null}
      * @throws IllegalStateException if this cipher is in a wrong state
      * (e.g., has not been initialized), does not accept AAD, or if
      * operating in either GCM or CCM mode and one of the {@code update}
@@ -247,7 +247,7 @@ class JceCipher implements CryptoCipher {
      * @param aad the buffer containing the Additional Authentication Data
      *
      * @throws IllegalArgumentException if the {@code aad}
-     * byte array is null
+     * byte array is {@code null}
      * @throws IllegalStateException if this cipher is in a wrong state
      * (e.g., has not been initialized), does not accept AAD, or if
      * operating in either GCM or CCM mode and one of the {@code update}

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSsl.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSsl.java
@@ -86,7 +86,7 @@ final class OpenSsl {
      * @param transformation the name of the transformation, e.g.,
      *        AES/CTR/NoPadding.
      * @return OpenSslCipher an {@code OpenSslCipher} object
-     * @throws NoSuchAlgorithmException if {@code transformation} is null,
+     * @throws NoSuchAlgorithmException if {@code transformation} is {@code null},
      *         empty, in an invalid format, or if OpenSsl doesn't implement the
      *         specified algorithm.
      * @throws NoSuchPaddingException if {@code transformation} contains a
@@ -108,7 +108,7 @@ final class OpenSsl {
     /**
      * Gets the failure reason when loading OpenSsl native.
      *
-     * @return the failure reason; null if it was loaded and initialized successfully
+     * @return the failure reason; {@code null} if it was loaded and initialized successfully
      */
     public static Throwable getLoadingFailureReason() {
         return loadingFailureReason;

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslCipher.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslCipher.java
@@ -224,7 +224,7 @@ final class OpenSslCipher implements CryptoCipher {
      * @param aad the buffer containing the Additional Authentication Data
      *
      * @throws IllegalArgumentException if the {@code aad}
-     * byte array is null
+     * byte array is {@code null}
      * @throws IllegalStateException if this opensslEngine is in a wrong state
      * (e.g., has not been initialized), does not accept AAD, or if
      * operating in either GCM mode and one of the {@code update}
@@ -264,7 +264,7 @@ final class OpenSslCipher implements CryptoCipher {
      * @param aad the buffer containing the Additional Authentication Data
      *
      * @throws IllegalArgumentException if the {@code aad}
-     * byte array is null
+     * byte array is {@code null}
      * @throws IllegalStateException if this opensslEngine is in a wrong state
      * (e.g., has not been initialized), does not accept AAD, or if
      * operating in either GCM mode and one of the {@code update}

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslGaloisCounterMode.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslGaloisCounterMode.java
@@ -203,7 +203,7 @@ final class OpenSslGaloisCounterMode extends AbstractOpenSslFeedbackCipher {
      * @param context The cipher context address
      * @param type CtrlValues
      * @param arg argument like a tag length
-     * @param data byte buffer or null
+     * @param data byte buffer or {@code null}
      * @return return 0 if there is any error, else return 1.
      */
     private int evpCipherCtxCtrl(final long context, final int type, final int arg, final ByteBuffer data) {

--- a/src/main/java/org/apache/commons/crypto/cipher/OpenSslNative.java
+++ b/src/main/java/org/apache/commons/crypto/cipher/OpenSslNative.java
@@ -43,7 +43,7 @@ final class OpenSslNative {
      * @param context The cipher context address
      * @param type CtrlValues
      * @param arg argument like a tag length
-     * @param data byte buffer or null
+     * @param data byte buffer or {@code null}
      * @return return 0 if there is any error, else return 1.
      */
     public static native int ctrl(long context, int type, int arg, byte[] data);

--- a/src/main/java/org/apache/commons/crypto/jna/OpenSslJna.java
+++ b/src/main/java/org/apache/commons/crypto/jna/OpenSslJna.java
@@ -43,14 +43,14 @@ public final class OpenSslJna {
     }
 
     /**
-     * @return The cipher class of JNA implementation
+     * @return The cipher class of JNA implementation.
      */
     public static Class<? extends CryptoCipher> getCipherClass() {
         return OpenSslJnaCipher.class;
     }
 
     /**
-     * @return The random class of JNA implementation
+     * @return The random class of JNA implementation.
      */
     public static Class<? extends CryptoRandom> getRandomClass() {
         return OpenSslJnaCryptoRandom.class;
@@ -68,14 +68,14 @@ public final class OpenSslJna {
     }
 
     /**
-     * @return the error of JNA
+     * @return the error of JNA.
      */
     public static Throwable initialisationError() {
         return OpenSslNativeJna.INIT_ERROR;
     }
 
     /**
-     * @return true if JNA native loads successfully
+     * @return {@code true} if JNA native loads successfully.
      */
     public static boolean isEnabled() {
         return OpenSslNativeJna.INIT_OK;

--- a/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCipher.java
+++ b/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCipher.java
@@ -325,7 +325,7 @@ final class OpenSslJnaCipher implements CryptoCipher {
      *
      * @param aad the buffer containing the Additional Authentication Data
      *
-     * @throws IllegalArgumentException      if the {@code aad} byte array is null
+     * @throws IllegalArgumentException      if the {@code aad} byte array is {@code null}
      * @throws IllegalStateException         if this opensslEngine is in a wrong
      *                                       state (e.g., has not been initialized),
      *                                       does not accept AAD, or if operating in
@@ -355,7 +355,7 @@ final class OpenSslJnaCipher implements CryptoCipher {
      *
      * @param aad the buffer containing the Additional Authentication Data
      *
-     * @throws IllegalArgumentException      if the {@code aad} byte array is null
+     * @throws IllegalArgumentException      if the {@code aad} byte array is {@code null}
      * @throws IllegalStateException         if this opensslEngine is in a wrong
      *                                       state (e.g., has not been initialized),
      *                                       does not accept AAD, or if operating in

--- a/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/jna/OpenSslJnaCryptoRandom.java
@@ -55,7 +55,7 @@ final class OpenSslJnaCryptoRandom implements CryptoRandom {
      * Constructs a {@link OpenSslJnaCryptoRandom}.
      *
      * @param props the configuration properties (not used)
-     * @throws GeneralSecurityException  if could not enable JNA access
+     * @throws GeneralSecurityException  if JNA access could not be enabled
      */
     public OpenSslJnaCryptoRandom(final Properties props) //NOPMD
             throws GeneralSecurityException {
@@ -105,7 +105,7 @@ final class OpenSslJnaCryptoRandom implements CryptoRandom {
 
     /**
      * Closes the rdrand engine.
-     * @param closing true when called while closing.
+     * @param closing {@code true} when called while closing.
      */
     private void closeRdrandEngine(final boolean closing) {
 
@@ -118,7 +118,7 @@ final class OpenSslJnaCryptoRandom implements CryptoRandom {
     /**
      * Checks if rdrand engine is used to retrieve random bytes
      *
-     * @return true if rdrand is used, false if default engine is used
+     * @return {@code true} if rdrand is used, {@code false} if default engine is used
      */
     public boolean isRdrandEnabled() {
         return rdrandEnabled;
@@ -151,7 +151,7 @@ final class OpenSslJnaCryptoRandom implements CryptoRandom {
 
     /**
      * @param retVal the result value of error.
-     * @param closing true when called while closing.
+     * @param closing {@code true} when called while closing.
      */
     private void throwOnError(final int retVal, final boolean closing) {
         if (retVal != 1) {

--- a/src/main/java/org/apache/commons/crypto/random/OpenSslCryptoRandom.java
+++ b/src/main/java/org/apache/commons/crypto/random/OpenSslCryptoRandom.java
@@ -83,7 +83,7 @@ final class OpenSslCryptoRandom implements CryptoRandom {
     /**
      * Judges whether native library was successfully loaded and initialized.
      *
-     * @return true if library was loaded and initialized
+     * @return {@code true} if library was loaded and initialized
      */
     public static boolean isNativeCodeEnabled() {
         return nativeEnabled;

--- a/src/main/java/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.java
+++ b/src/main/java/org/apache/commons/crypto/random/OpenSslCryptoRandomNative.java
@@ -32,11 +32,11 @@ final class OpenSslCryptoRandomNative {
     public static native void initSR();
 
     /**
-     * Judges whether use {@link OpenSslCryptoRandomNative} to generate the
+     * Judges whether to use {@link OpenSslCryptoRandomNative} to generate the
      * user-specified number of random bits.
      *
      * @param bytes the array to be filled in with random bytes.
-     * @return true if use {@link OpenSslCryptoRandomNative} to generate the
+     * @return {@code true} if use {@link OpenSslCryptoRandomNative} to generate the
      *         user-specified number of random bits.
      */
     public static native boolean nextRandBytes(byte[] bytes);

--- a/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CryptoInputStream.java
@@ -493,7 +493,7 @@ public class CryptoInputStream extends InputStream implements ReadableByteChanne
     /**
      * Overrides the {@link InputStream#markSupported()}.
      *
-     * @return false, the {@link CtrCryptoInputStream} don't support the mark
+     * @return {@code false} if the {@link CtrCryptoInputStream} don't support the mark
      *         method.
      */
     @Override

--- a/src/main/java/org/apache/commons/crypto/stream/CtrCryptoInputStream.java
+++ b/src/main/java/org/apache/commons/crypto/stream/CtrCryptoInputStream.java
@@ -487,7 +487,7 @@ public class CtrCryptoInputStream extends CryptoInputStream {
      * This method is executed immediately after decryption. Checks whether
      * cipher should be updated and recalculate padding if needed.
      *
-     * @param position the given position in the data..
+     * @param position the given position in the data.
      * @return the byte.
      * @throws IOException if an I/O error occurs.
      */

--- a/src/main/java/org/apache/commons/crypto/stream/input/Input.java
+++ b/src/main/java/org/apache/commons/crypto/stream/input/Input.java
@@ -28,7 +28,7 @@ import org.apache.commons.crypto.stream.CryptoInputStream;
 /**
  * The Input interface abstract the input source of
  * {@link CryptoInputStream} so that different implementation of input can
- * be used. The implementation Input interface will usually wraps an input
+ * be used. The implementation Input interface will usually wrap an input
  * mechanism such as {@link InputStream} or
  * {@link ReadableByteChannel}.
  */

--- a/src/main/java/org/apache/commons/crypto/stream/output/Output.java
+++ b/src/main/java/org/apache/commons/crypto/stream/output/Output.java
@@ -28,7 +28,7 @@ import org.apache.commons.crypto.stream.CryptoOutputStream;
 /**
  * The Output interface abstract the output target of
  * {@link CryptoOutputStream} so that different implementation of output
- * can be used. The implementation Output interface will usually wraps an output
+ * can be used. The implementation Output interface will usually wrap an output
  * mechanism such as {@link OutputStream} or
  * {@link WritableByteChannel}.
  */

--- a/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
@@ -69,11 +69,11 @@ public final class ReflectionUtils {
     }
 
     /**
-     * Loads a class by name, returning null rather than throwing an exception if it
+     * Loads a class by name, returning {@code null} rather than throwing an exception if it
      * couldn't be loaded. This is to avoid the overhead of creating an exception.
      *
      * @param name the class name.
-     * @return the class object, or null if it could not be found.
+     * @return the class object, or {@code null} if it could not be found.
      */
     private static Class<?> getClassByNameOrNull(final String name) {
         final Map<String, WeakReference<Class<?>>> map;

--- a/src/main/java/org/apache/commons/crypto/utils/Utils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/Utils.java
@@ -84,7 +84,7 @@ public final class Utils {
      * the calling method.
      *
      * @param expression a boolean expression.
-     * @throws IllegalArgumentException if expression is false.
+     * @throws IllegalArgumentException if expression is {@code false}.
      */
     public static void checkArgument(final boolean expression) {
         if (!expression) {
@@ -97,9 +97,8 @@ public final class Utils {
      *
      * @param expression a boolean expression.
      * @param errorMessage the exception message to use if the check fails; will
-     *        be converted to a string using <code>String
-     *                     .valueOf(Object)</code>.
-     * @throws IllegalArgumentException if expression is false.
+     *        be converted to a string using <code>String.valueOf(Object)</code>.
+     * @throws IllegalArgumentException if expression is {@code false}.
      */
     public static void checkArgument(final boolean expression, final Object errorMessage) {
         if (!expression) {
@@ -109,12 +108,12 @@ public final class Utils {
 
     /**
      * Ensures that an object reference passed as a parameter to the calling
-     * method is not null.
+     * method is not {@code null}.
      *
      * @param <T> the type of the object reference to be checked.
      * @param reference an object reference.
      * @return the non-null reference that was validated.
-     * @throws NullPointerException if reference is null.
+     * @throws NullPointerException if reference is {@code null}.
      * @deprecated Use {@link Objects#requireNonNull(Object)}.
      */
     @Deprecated
@@ -127,7 +126,7 @@ public final class Utils {
      * instance, but not involving any parameters to the calling method.
      *
      * @param expression a boolean expression.
-     * @throws IllegalStateException if expression is false.
+     * @throws IllegalStateException if expression is {@code false}.
      */
     public static void checkState(final boolean expression) {
         checkState(expression, null);
@@ -138,8 +137,8 @@ public final class Utils {
      * instance, but not involving any parameters to the calling method.
      *
      * @param expression a boolean expression.
-     * @param message Error message for the exception when the expression is false.
-     * @throws IllegalStateException if expression is false.
+     * @param message Error message for the exception when the expression is {@code false}.
+     * @throws IllegalStateException if expression is {@code false}.
      */
     public static void checkState(final boolean expression, final String message) {
         if (!expression) {
@@ -151,7 +150,7 @@ public final class Utils {
      * Helper method to create a CryptoCipher instance and throws only
      * IOException.
      *
-     * @param properties The {@code Properties} class represents a set of
+     * @param properties The {@link Properties} class represents a set of
      *        properties.
      * @param transformation the name of the transformation, e.g.,
      * <i>AES/CBC/PKCS5Padding</i>.
@@ -211,10 +210,10 @@ public final class Utils {
 
     /**
      * Splits class names sequence into substrings, Trim each substring into an
-     * entry, and returns an list of the entries.
+     * entry, and returns a list of the entries.
      *
      * @param clazzNames a string consist of a list of the entries joined by a
-     *        delimiter, may be null or empty in which case an empty list is returned.
+     *        delimiter, may be {@code null} or empty in which case an empty list is returned.
      * @param separator a delimiter for the input string.
      * @return a list of class entries.
      */

--- a/src/site/xdoc/faq.xml
+++ b/src/site/xdoc/faq.xml
@@ -33,7 +33,7 @@ limitations under the License.
       <dl>
         <dt>OPENSSL</dt><dd>OpenSSL based JNI implementation shipped with Commons Crypto.</dd>
         <dt>JAVA</dt><dd>The SecureRandom implementation from the JVM.</dd>
-        <dt>OS</dt><dd>The OS random device implementation. May not be available on some operation systems.</dd>
+        <dt>OS</dt><dd>The OS random device implementation. May not be available on some operating systems.</dd>
       </dl>
 
       When calling <code>CryptoRandomFactory.getCryptoRandom()</code>, Commons Crypto tries to use the OpenSSL

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -37,7 +37,7 @@ limitations under the License.
       <li>Cipher API for low level cryptographic operations.</li>
       <li>Secure true random number generator.</li>
       <li>Java stream API for high level stream
-        encyrption/decryption.
+        encryption/decryption.
       </li>
       <li>High performance AES encryption/decryption optimized with Intel AES-NI.
       </li>

--- a/src/site/xdoc/proposal.xml
+++ b/src/site/xdoc/proposal.xml
@@ -31,7 +31,7 @@ limitations under the License.
 <subsection name="(0) Rationale">
   <p>
    Providing Java based optimized and high performance cryptographic IO streams for
-   the applications who wants to implement the data encryption. It also provides cipher
+   the applications that want to implement the data encryption. It also provides cipher
    level API to use. It does provide the openssl API integration and provide the fallback
    mechanism to use JCE when openssl library unavailable.
   </p>
@@ -41,7 +41,7 @@ limitations under the License.
   <p>
       This proposal is to create a package of cryptographic IO classes with the integration
       of OpenSSL library.
-      It focuses on AES-NI optimizations mainly and it can be extended to other algorithms
+      It focuses on AES-NI optimizations mainly, and it can be extended to other algorithms
       based on demand from the users later.
   </p>
 

--- a/src/site/xdoc/userguide.xml
+++ b/src/site/xdoc/userguide.xml
@@ -54,7 +54,7 @@
               </a>
             </td>
             <td>
-              The interface wraps the underlying stream and it automatically encrypts
+              The interface wraps the underlying stream, and it automatically encrypts
               the stream when data is written and decrypts the stream when data is
               read.
             </td>
@@ -94,7 +94,7 @@
 
         <h4>Usage of Cipher API</h4>
         <p>
-          Cipher provides an cryptographic interface for encryption and decryption.
+          Cipher provides a cryptographic interface for encryption and decryption.
           We provide two kind of implementations: JCE Cipher and OpenSSL Cipher. The
           JCE implementation uses JCE provider and the OpenSSL implementation uses
           Intel&reg; AES New Instructions (Intel&reg; AES NI).

--- a/src/test/java/org/apache/commons/crypto/NativeCodeLoaderTest.java
+++ b/src/test/java/org/apache/commons/crypto/NativeCodeLoaderTest.java
@@ -65,7 +65,7 @@ public class NativeCodeLoaderTest {
     @Test
     @Disabled("Seems to cause issues with other tests on Linux; disable for now")
     // It causes problems because the system properties are temporarily changed.
-    // However properties are only fetched once, thus the test either corrupts the settings
+    // However, properties are only fetched once, thus the test either corrupts the settings
     // or does not work, depending on the order of tests.
     public void testUnSuccessfulLoad() throws Exception {
         final String nameKey = System.getProperty(Crypto.LIB_NAME_KEY);


### PR DESCRIPTION
- fixes grammar issues in JavaDoc and code comments.
- fixes some typos found along the way.
- improves JavaDoc, highlighting the keywords: `null`, `true`, `false`.