### PR TITLE
Set MacOS Runner to 11 and Fix Unknown Method Error

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        # ubuntu-latest uses OpenSSL 3 which breaks tests
+        # macos-latest and ubuntu-latest uses OpenSSL 3 which breaks tests
         os: [macos-11, ubuntu-20.04, windows-latest]
         java: [ 8, 11, 17 ]
         experimental: [false]

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         # ubuntu-latest uses OpenSSL 3 which breaks tests
-        os: [macos-latest, ubuntu-20.04, windows-latest]
+        os: [macos-11, ubuntu-20.04, windows-latest]
         java: [ 8, 11, 17 ]
         experimental: [false]
 #        include:

--- a/src/test/java/org/apache/commons/crypto/AbstractBenchmark.java
+++ b/src/test/java/org/apache/commons/crypto/AbstractBenchmark.java
@@ -29,7 +29,6 @@ import org.apache.commons.crypto.cipher.CryptoCipherFactory;
 import org.apache.commons.crypto.random.CryptoRandom;
 import org.apache.commons.crypto.random.CryptoRandomFactory;
 import org.apache.commons.crypto.utils.AES;
-import org.apache.commons.crypto.utils.Utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -39,7 +38,7 @@ public abstract class AbstractBenchmark {
                 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16 };
     private static final byte[] IV = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
-    private static final SecretKeySpec keySpec = Utils.newSecretKeySpec(KEY);
+    private static final SecretKeySpec keySpec = AES.newSecretKeySpec(KEY);
     private static final IvParameterSpec ivSpec = new IvParameterSpec(IV);
     private static final byte[] BUFFER = new byte[1000];
 


### PR DESCRIPTION
Did a fork and build to get reacclimatized to the code base.  A few observations.  One, the build contained an unknown method error.  Two, the test matrix was pulling macos-latest, which used OpenSSL3 and broke the tests.  Three, the CI pipeline isn't running the full set of tests.  This PR addresses the first two issues.  I'm not sure what the rationale was for running only a small subset of tests in GitHub actions, but we may want to consider running them all, at least in some of the matrix builds.