### PR TITLE
[CRYPTO-169] Add protection for the `ExceptionInInitializerError` scenario to the `CryptoRandomFactory#getCryptoRandom(Properties)` method

### DIFF
--- a/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
+++ b/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
@@ -198,6 +198,14 @@ public class CryptoRandomFactory {
             } catch (final Exception e) {
                 lastException = e;
                 errorMessage.append("CryptoRandom: [" + className + "] failed with " + e.getMessage());
+            } catch (final ExceptionInInitializerError initializerError) {
+                Throwable t = initializerError.getException();
+                if (t instanceof Exception) {
+                    lastException = (Exception) t;
+                    errorMessage.append("CryptoRandom: [" + className + "] initialization failed with " + t.getMessage());
+                } else {
+                    throw initializerError;
+                }
             }
         }
 

--- a/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
+++ b/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
@@ -199,7 +199,7 @@ public class CryptoRandomFactory {
                 lastException = e;
                 errorMessage.append("CryptoRandom: [" + className + "] failed with " + e.getMessage());
             } catch (final ExceptionInInitializerError initializerError) {
-                Throwable t = initializerError.getException();
+                Throwable t = initializerError.getCause();
                 if (t instanceof Exception) {
                     lastException = (Exception) t;
                     errorMessage.append("CryptoRandom: [" + className + "] initialization failed with " + t.getMessage());

--- a/src/test/java/org/apache/commons/crypto/random/CryptoRandomFactoryTest.java
+++ b/src/test/java/org/apache/commons/crypto/random/CryptoRandomFactoryTest.java
@@ -141,4 +141,14 @@ public class CryptoRandomFactoryTest {
         assertThrows(NullPointerException.class, () -> CryptoRandomFactory.getCryptoRandom(null));
     }
 
+    @Test
+    public void testExceptionInInitializerErrorRandom() throws GeneralSecurityException, IOException {
+        final Properties properties = new Properties();
+        String classes = ExceptionInInitializerErrorRandom.class.getName().concat(",")
+            .concat(CryptoRandomFactory.RandomProvider.JAVA.getClassName());
+        properties.setProperty(CryptoRandomFactory.CLASSES_KEY, classes);
+        try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
+            assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/crypto/random/ExceptionInInitializerErrorRandom.java
+++ b/src/test/java/org/apache/commons/crypto/random/ExceptionInInitializerErrorRandom.java
@@ -30,7 +30,7 @@ public class ExceptionInInitializerErrorRandom implements CryptoRandom {
     }
 
     private static void check() throws GeneralSecurityException {
-        throw new GeneralSecurityException("Native library is not loaded");
+        throw new GeneralSecurityException("ExceptionInInitializerErrorRandom init failed");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/crypto/random/ExceptionInInitializerErrorRandom.java
+++ b/src/test/java/org/apache/commons/crypto/random/ExceptionInInitializerErrorRandom.java
@@ -39,9 +39,11 @@ public class ExceptionInInitializerErrorRandom implements CryptoRandom {
 
     @Override
     public void nextBytes(byte[] bytes) {
+        // empty
     }
 
     @Override
     public void close() throws IOException {
+        // empty
     }
 }

--- a/src/test/java/org/apache/commons/crypto/random/ExceptionInInitializerErrorRandom.java
+++ b/src/test/java/org/apache/commons/crypto/random/ExceptionInInitializerErrorRandom.java
@@ -19,6 +19,10 @@ package org.apache.commons.crypto.random;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
+/**
+ * Simulates scenarios where {@link OpenSslCryptoRandom} fails in the static code block {@code checkNative()} or
+ * {@code !OpenSslCryptoRandomNative.nextRandBytes(new byte[1])} is false.
+ */
 public class ExceptionInInitializerErrorRandom implements CryptoRandom {
 
     static {

--- a/src/test/java/org/apache/commons/crypto/random/ExceptionInInitializerErrorRandom.java
+++ b/src/test/java/org/apache/commons/crypto/random/ExceptionInInitializerErrorRandom.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.crypto.random;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+public class ExceptionInInitializerErrorRandom implements CryptoRandom {
+
+    static {
+        try {
+            check();
+        } catch (final GeneralSecurityException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void check() throws GeneralSecurityException {
+        throw new GeneralSecurityException("Native library is not loaded");
+    }
+
+    @Override
+    public void nextBytes(byte[] bytes) {
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}


### PR DESCRIPTION
In version 1.2.0 of `commons-crypto`, the static initialization code block of `o.a.c.crypto.random.OpenSslCryptoRandom` may throw a `GeneralSecurityException` wrapped by `IllegalStateException`, which ultimately gets wrapped into `j.l.ExceptionInInitializerError` by Java's own mechanism.

This results in behavior differences when running the statement 

```java
org.apache.commons.crypto.random.CryptoRandomFactory#getCryptoRandom(new java.util.Properties());
```
on platforms that do not support `OpenSslCryptoRandom` compared to when using `commons-crypto` 1.1.0 (e.g. Apple Silicon)

- `commons-crypto` 1.1.0

After `OpenSslCryptoRandom` initialization fails, it tries to initialize `JavaCryptoRandom`, and `JavaCryptoRandom` can be successfully initialized and return results.

- `commons-crypto` 1.2.0

After `OpenSslCryptoRandom` initialization fails, it throws an `ExceptionInInitializerError`. Since the `CryptoRandomFactory#getCryptoRandom` method does not catch `ExceptionInInitializerError` and perform fault tolerance, `ExceptionInInitializerError` continues to be thrown upward, losing the opportunity to try to initialize `JavaCryptoRandom`.

Therefore, this PR adds the catch and fault tolerance for `ExceptionInInitializerError` in the `CryptoRandomFactory#getCryptoRandom` method to keep it behaving similarly to `commons-crypto` 1.1.0.