### PR TITLE
[CRYPTO-169][FOLLOWUP] Fix  reentrancy of `CryptoRandomFactory#getCryptoRandom`

### DIFF
--- a/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
+++ b/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
@@ -208,9 +208,13 @@ public class CryptoRandomFactory {
                 }
             } catch (final NoClassDefFoundError noClassDefFoundError) {
                 Throwable initializerError = noClassDefFoundError.getCause();
+                String message = noClassDefFoundError.getMessage();
                 if (initializerError instanceof ExceptionInInitializerError) {
-                    lastException =  new IllegalStateException(initializerError.getMessage());
+                    lastException = new IllegalStateException(initializerError.getMessage());
                     errorMessage.append("CryptoRandom: [" + className + "] initialization failed with " + initializerError.getMessage());
+                } else if (initializerError == null && message != null && message.startsWith("Could not initialize class")) {
+                    lastException = new IllegalStateException(message);
+                    errorMessage.append("CryptoRandom: [" + className + "] initialization failed with " + message);
                 } else {
                     throw noClassDefFoundError;
                 }

--- a/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
+++ b/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
@@ -206,6 +206,14 @@ public class CryptoRandomFactory {
                 } else {
                     throw initializerError;
                 }
+            } catch (final NoClassDefFoundError noClassDefFoundError) {
+                Throwable initializerError = noClassDefFoundError.getCause();
+                if (initializerError instanceof ExceptionInInitializerError) {
+                    lastException =  new IllegalStateException(initializerError.getMessage());
+                    errorMessage.append("CryptoRandom: [" + className + "] initialization failed with " + initializerError.getMessage());
+                } else {
+                    throw noClassDefFoundError;
+                }
             }
         }
 

--- a/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
+++ b/src/main/java/org/apache/commons/crypto/random/CryptoRandomFactory.java
@@ -198,26 +198,6 @@ public class CryptoRandomFactory {
             } catch (final Exception e) {
                 lastException = e;
                 errorMessage.append("CryptoRandom: [" + className + "] failed with " + e.getMessage());
-            } catch (final ExceptionInInitializerError initializerError) {
-                Throwable t = initializerError.getCause();
-                if (t instanceof Exception) {
-                    lastException = (Exception) t;
-                    errorMessage.append("CryptoRandom: [" + className + "] initialization failed with " + t.getMessage());
-                } else {
-                    throw initializerError;
-                }
-            } catch (final NoClassDefFoundError noClassDefFoundError) {
-                Throwable initializerError = noClassDefFoundError.getCause();
-                String message = noClassDefFoundError.getMessage();
-                if (initializerError instanceof ExceptionInInitializerError) {
-                    lastException = new IllegalStateException(initializerError.getMessage());
-                    errorMessage.append("CryptoRandom: [" + className + "] initialization failed with " + initializerError.getMessage());
-                } else if (initializerError == null && message != null && message.startsWith("Could not initialize class")) {
-                    lastException = new IllegalStateException(message);
-                    errorMessage.append("CryptoRandom: [" + className + "] initialization failed with " + message);
-                } else {
-                    throw noClassDefFoundError;
-                }
             }
         }
 

--- a/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
@@ -19,7 +19,10 @@ package org.apache.commons.crypto.utils;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.crypto.cipher.CryptoCipher;

--- a/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.apache.commons.crypto.cipher.CryptoCipher;
 
@@ -43,7 +44,7 @@ public final class ReflectionUtils {
     }
 
     private static final Map<ClassLoader, Map<String, WeakReference<Class<?>>>> CACHE_CLASSES = new WeakHashMap<>();
-    private static final Map<ClassLoader, Set<String>> INIT_ERROR_CLASSES = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<ClassLoader, Set<String>> INIT_ERROR_CLASSES = new ConcurrentHashMap<>();
 
     private static final ClassLoader CLASSLOADER;
 

--- a/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/ReflectionUtils.java
@@ -21,7 +21,9 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/src/test/java/org/apache/commons/crypto/random/CryptoRandomFactoryTest.java
+++ b/src/test/java/org/apache/commons/crypto/random/CryptoRandomFactoryTest.java
@@ -88,6 +88,23 @@ public class CryptoRandomFactoryTest {
     }
 
     @Test
+    public void testReentrancyOfExceptionInInitializerErrorRandom() throws GeneralSecurityException, IOException {
+        final Properties properties = new Properties();
+        String classes = ExceptionInInitializerErrorRandom.class.getName().concat(",")
+                .concat(CryptoRandomFactory.RandomProvider.JAVA.getClassName());
+        properties.setProperty(CryptoRandomFactory.CLASSES_KEY, classes);
+        try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
+            assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());
+        }
+        try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
+            assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());
+        }
+        try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
+            assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());
+        }
+    }
+
+    @Test
     public void testFailingRandom() {
         final Properties properties = new Properties();
         properties.setProperty(CryptoRandomFactory.CLASSES_KEY, FailingRandom.class.getName());

--- a/src/test/java/org/apache/commons/crypto/random/CryptoRandomFactoryTest.java
+++ b/src/test/java/org/apache/commons/crypto/random/CryptoRandomFactoryTest.java
@@ -82,17 +82,7 @@ public class CryptoRandomFactoryTest {
         String classes = ExceptionInInitializerErrorRandom.class.getName().concat(",")
             .concat(CryptoRandomFactory.RandomProvider.JAVA.getClassName());
         properties.setProperty(CryptoRandomFactory.CLASSES_KEY, classes);
-        try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
-            assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());
-        }
-    }
-
-    @Test
-    public void testReentrancyOfExceptionInInitializerErrorRandom() throws GeneralSecurityException, IOException {
-        final Properties properties = new Properties();
-        String classes = ExceptionInInitializerErrorRandom.class.getName().concat(",")
-                .concat(CryptoRandomFactory.RandomProvider.JAVA.getClassName());
-        properties.setProperty(CryptoRandomFactory.CLASSES_KEY, classes);
+        // Invoke 3 times to test the reentrancy of the method in the scenario of class initialization failure.
         for (int i = 0; i < 3; i++) {
             try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
                 assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());

--- a/src/test/java/org/apache/commons/crypto/random/CryptoRandomFactoryTest.java
+++ b/src/test/java/org/apache/commons/crypto/random/CryptoRandomFactoryTest.java
@@ -93,14 +93,10 @@ public class CryptoRandomFactoryTest {
         String classes = ExceptionInInitializerErrorRandom.class.getName().concat(",")
                 .concat(CryptoRandomFactory.RandomProvider.JAVA.getClassName());
         properties.setProperty(CryptoRandomFactory.CLASSES_KEY, classes);
-        try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
-            assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());
-        }
-        try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
-            assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());
-        }
-        try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
-            assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());
+        for (int i = 0; i < 3; i++) {
+            try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
+                assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());
+            }
         }
     }
 


### PR DESCRIPTION
There are some issues with the reentrancy of `CryptoRandomFactory.getCryptoRandom(properties)` method.

For the following test case:

```java
@Test
public void testReentrancyOfExceptionInInitializerErrorRandom() throws GeneralSecurityException, IOException {
    final Properties properties = new Properties();
    String classes = ExceptionInInitializerErrorRandom.class.getName().concat(",")
            .concat(CryptoRandomFactory.RandomProvider.JAVA.getClassName());
    properties.setProperty(CryptoRandomFactory.CLASSES_KEY, classes);
    for (int i = 0; i < 3; i++) {
        try (final CryptoRandom random = CryptoRandomFactory.getCryptoRandom(properties)) {
            assertEquals(JavaCryptoRandom.class.getName(), random.getClass().getName());
         }
    }
} 
```
The second call to `CryptoRandomFactory.getCryptoRandom(properties)` will result in the following error:

```java
java.lang.NoClassDefFoundError: Could not initialize class org.apache.commons.crypto.random.ExceptionInInitializerErrorRandom
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:534)
	at java.base/java.lang.Class.forName(Class.java:513)
	at org.apache.commons.crypto.utils.ReflectionUtils.getClassByNameOrNull(ReflectionUtils.java:93)
	at org.apache.commons.crypto.utils.ReflectionUtils.getClassByName(ReflectionUtils.java:64)
	at org.apache.commons.crypto.random.CryptoRandomFactory.getCryptoRandom(CryptoRandomFactory.java:189)
	at org.apache.commons.crypto.random.CryptoRandomFactoryTest.testReentrancyOfExceptionInInitializerErrorRandom(CryptoRandomFactoryTest.java:99)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.IllegalStateException: java.security.GeneralSecurityException: ExceptionInInitializerErrorRandom init failed [in thread "main"]
	at org.apache.commons.crypto.random.ExceptionInInitializerErrorRandom.<clinit>(ExceptionInInitializerErrorRandom.java:32)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:534)
	at java.base/java.lang.Class.forName(Class.java:513)
	at org.apache.commons.crypto.utils.ReflectionUtils.getClassByNameOrNull(ReflectionUtils.java:93)
	at org.apache.commons.crypto.utils.ReflectionUtils.getClassByName(ReflectionUtils.java:64)
	at org.apache.commons.crypto.random.CryptoRandomFactory.getCryptoRandom(CryptoRandomFactory.java:189)
	at org.apache.commons.crypto.random.CryptoRandomFactoryTest.testReentrancyOfExceptionInInitializerErrorRandom(CryptoRandomFactoryTest.java:96)
	... 3 more
```

This is due to the `Class.forName` method. If the first initialization fails, subsequent identical calls will not attempt to initialize the class again, but will throw `NoClassDefFoundError`.

So this PR changes to add a collection in `ReflectionUtils` to record the class names that failed to initialize (recorded when `Class.forName` first fails to initialize), to ensure that known failed initialization classes will not be attempted to load repeatedly.

This PR removes the modification of the `CryptoRandomFactory#getCryptoRandom` method in https://github.com/apache/commons-crypto/pull/258, because under the above changes, `CryptoRandomFactory#getCryptoRandom` will no longer catch ExceptionInInitializerError.