### PR TITLE
CRYPTO-172: Add support for Linux-riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ linux-armhf:
 linux-aarch64:
 	$(MAKE) native CROSS_PREFIX=aarch64-linux-gnu- OS_NAME=Linux OS_ARCH=aarch64
 
+# for cross-compilation on Ubuntu, install the g++-riscv64-linux-gnu
+linux-riscv64:
+	$(MAKE) native CROSS_PREFIX=riscv64-linux-gnu- OS_NAME=Linux OS_ARCH=riscv64
+
 clean-native-linux32:
 	$(MAKE) clean-native OS_NAME=Linux OS_ARCH=x86
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -53,7 +53,7 @@ endif
 
 # os=Default is meant to be generic Unix/Linux
 # The following list must include all OS entries beloe (apart from Default)
-known_os_archs := Linux-x86 Linux-x86_64 Linux-aarch64 Linux-arm Linux-armhf Linux-ppc Linux-ppc64 Mac-x86 Mac-x86_64 Mac-arm64 Mac-aarch64 FreeBSD-x86_64 Windows-x86 Windows-x86_64 SunOS-x86 SunOS-sparc SunOS-x86_64 AIX-ppc64
+known_os_archs := Linux-x86 Linux-x86_64 Linux-aarch64 Linux-arm Linux-armhf Linux-ppc Linux-ppc64 Linux-riscv64 Mac-x86 Mac-x86_64 Mac-arm64 Mac-aarch64 FreeBSD-x86_64 Windows-x86 Windows-x86_64 SunOS-x86 SunOS-sparc SunOS-x86_64 AIX-ppc64
 os_arch := $(OS_NAME)-$(OS_ARCH)
 
 ifeq (,$(findstring $(strip $(os_arch)),$(known_os_archs)))
@@ -189,6 +189,16 @@ Linux-aarch64_LINKFLAGS := -shared -static-libgcc
 Linux-aarch64_LIBNAME   := libcommons-crypto.so
 Linux-aarch64_LIBNAME_OSSL3 := libcommons-crypto-ossl3.so
 Linux-aarch64_COMMONS_CRYPTO_FLAGS  :=
+
+Linux-riscv64_CC        := $(CROSS_PREFIX)gcc
+Linux-riscv64_CXX       := $(CROSS_PREFIX)g++
+Linux-riscv64_STRIP     := $(CROSS_PREFIX)strip
+Linux-riscv64_CXXFLAGS  := -Ilib/inc_linux -I"$(JAVA_HOME)/include" -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -Wall -Werror
+Linux-riscv64_CFLAGS    := -Ilib/inc_linux -I"$(JAVA_HOME)/include" -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -Wall -Werror
+Linux-riscv64_LINKFLAGS := -shared -static-libgcc
+Linux-riscv64_LIBNAME   := libcommons-crypto.so
+Linux-riscv64_LIBNAME_OSSL3 := libcommons-crypto-ossl3.so
+Linux-riscv64_COMMONS_CRYPTO_FLAGS  :=
 
 ifndef Mac_INC_OPENSSL
 Mac_INC_OPENSSL   := /usr/local/opt/openssl/include

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,12 @@ The following provides more details on the included cryptographic software:
       </properties>
     </profile>
     <profile>
+      <id>linux-riscv64</id>
+      <properties>
+        <target.name>linux-riscv64</target.name>
+      </properties>
+    </profile>
+    <profile>
       <id>jacoco</id>
       <activation>
         <file>

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -30,6 +30,8 @@ RUN apt-get update && apt-get --assume-yes install software-properties-common \
       && apt-get --assume-yes install libssl-dev \
       && apt-get --assume-yes install gcc-aarch64-linux-gnu \
       && apt-get --assume-yes install g++-aarch64-linux-gnu \
+      && apt-get --assume-yes install gcc-riscv64-linux-gnu \
+      && apt-get --assume-yes install g++-riscv64-linux-gnu \
       && apt-get --assume-yes install mingw-w64 \
       && apt-get --assume-yes install wget \
       && apt-get --assume-yes install dos2unix \
@@ -45,8 +47,8 @@ RUN dpkg --add-architecture i386 && apt-get update \
       && apt-get --assume-yes install g++-arm-linux-gnueabihf
 
 # Do this separately to make upgrades easier
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz \
-&& tar xf apache-maven-*.tar.gz -C /opt && ln -s /opt/apache-maven-3.8.7 /opt/maven
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz \
+&& tar xf apache-maven-*.tar.gz -C /opt && ln -s /opt/apache-maven-3.8.8 /opt/maven
 
 # Ensure we are in the correct directory (this will be overlaid by the virtual mount)
 WORKDIR /home/crypto

--- a/src/docker/build.sh
+++ b/src/docker/build.sh
@@ -29,6 +29,7 @@ mvn -V package -Drat.skip
 
 # use process-classes rather than package to speed up builds
 mvn -DskipTests -Drat.skip process-classes -P linux-aarch64
+mvn -DskipTests -Drat.skip process-classes -P linux-riscv64
 mvn -DskipTests -Drat.skip process-classes -P win64
 mvn -DskipTests -Drat.skip process-classes -P linux64
 

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -84,6 +84,7 @@ limitations under the License.
       <li>debian-amd64; OpenSSL 1.1.1g</li>
       <li>debian-arm64; OpenSSL 1.1.1f</li>
       <li>linux-aarch64; OpenSSL 1.0.2k-fips</li>
+      <li>linux-riscv64; OpenSSL 1.1.1f</li>
       <li>Linux x86_64; OpenSSL 1.1.1</li>
       <li>Windows 64 (mingw64); OpenSSL 1.1.1d</li>
     </ul>


### PR DESCRIPTION
Java supports RISC-V since version 19. Given Apache Common Crypto is a commonly used library in the Java ecosystem, it's important for it to support RISC-V as well.

This patch adds the linux-riscv64 target similarly to linux-aarch64.

I've verified it builds with `docker compose -f src/docker/docker-compose.yaml run crypto src/docker/build.sh`.