### PR TITLE
Bump to Maven 3.8.8

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -45,8 +45,8 @@ RUN dpkg --add-architecture i386 && apt-get update \
       && apt-get --assume-yes install g++-arm-linux-gnueabihf
 
 # Do this separately to make upgrades easier
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz \
-&& tar xf apache-maven-*.tar.gz -C /opt && ln -s /opt/apache-maven-3.8.7 /opt/maven
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz \
+&& tar xf apache-maven-*.tar.gz -C /opt && ln -s /opt/apache-maven-3.8.8 /opt/maven
 
 # Ensure we are in the correct directory (this will be overlaid by the virtual mount)
 WORKDIR /home/crypto


### PR DESCRIPTION
Maven 3.8.7 is not available for download anymore, so the previous URL would return a 404